### PR TITLE
Alter Ensemble Scripts to Prevent Crashing

### DIFF
--- a/12_model_ens_inference.py
+++ b/12_model_ens_inference.py
@@ -644,7 +644,7 @@ def main():
         
     print('done')
     
-    vr = VocalRemover(model, device, args.window_size)
+    vr = VocalRemover(model, device, max(args.window_size,320))
 
     if args.tta:
         pred, X_mag, X_phase = vr.inference_tta(X_spec_m, {'value': args.aggressiveness, 'split_bin': mp.param['band'][1]['crop_stop']})
@@ -759,7 +759,7 @@ def main():
         
     print('done')
     
-    vr = VocalRemover(model, device, args.window_size)
+    vr = VocalRemover(model, device, max(args.window_size,320))
 
     if args.tta:
         pred, X_mag, X_phase = vr.inference_tta(X_spec_m, {'value': args.aggressiveness, 'split_bin': mp.param['band'][1]['crop_stop']})
@@ -874,7 +874,7 @@ def main():
         
     print('done')
     
-    vr = VocalRemover(model, device, args.window_size)
+    vr = VocalRemover(model, device, max(args.window_size,320))
 
     if args.tta:
         pred, X_mag, X_phase = vr.inference_tta(X_spec_m, {'value': args.aggressiveness, 'split_bin': mp.param['band'][1]['crop_stop']})

--- a/4Band_ens_inference.py
+++ b/4Band_ens_inference.py
@@ -632,7 +632,7 @@ def main():
         
     print('done')
     
-    vr = VocalRemover(model, device, args.window_size)
+    vr = VocalRemover(model, device, max(args.window_size,320))
 
     if args.tta:
         pred, X_mag, X_phase = vr.inference_tta(X_spec_m, {'value': args.aggressiveness, 'split_bin': mp.param['band'][1]['crop_stop']})
@@ -747,7 +747,7 @@ def main():
         
     print('done')
     
-    vr = VocalRemover(model, device, args.window_size)
+    vr = VocalRemover(model, device, max(args.window_size,320))
 
     if args.tta:
         pred, X_mag, X_phase = vr.inference_tta(X_spec_m, {'value': args.aggressiveness, 'split_bin': mp.param['band'][1]['crop_stop']})
@@ -862,7 +862,7 @@ def main():
         
     print('done')
     
-    vr = VocalRemover(model, device, args.window_size)
+    vr = VocalRemover(model, device, max(args.window_size,320))
 
     if args.tta:
         pred, X_mag, X_phase = vr.inference_tta(X_spec_m, {'value': args.aggressiveness, 'split_bin': mp.param['band'][1]['crop_stop']})


### PR DESCRIPTION
This change should prevent 4Band_ens_inference.py from crashing or only partially completing all the inference rounds when the window size is set below 320.
The NewLayer models fail when the size is below 320, so this change simply sets a lower limit of 320 for those rounds.