### PR TITLE
Fixed CUDA out of memory

### DIFF
--- a/ensemble_inference.py
+++ b/ensemble_inference.py
@@ -334,6 +334,8 @@ def main():
                  _, bin_image = cv2.imencode('.jpg', image)
                  bin_image.tofile(f)
 
+        torch.cuda.empty_cache()
+
         # print('Total time: {0:.{1}f}s'.format(time.time() - start_time, 1))
 
 #ENSEMBLING-BEGIN


### PR DESCRIPTION
This change will clear the torch cache on each function call and avoids errors like these:
```
RuntimeError: CUDA out of memory. Tried to allocate 288.00 MiB (GPU 0; 3.94 GiB total capacity; 793.31 MiB already allocated; 1.89 GiB free; 1008.73 MiB allowed; 936.00 MiB reserved in total by PyTorch)
```