### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/UVR.py
+++ b/UVR.py
@@ -154,7 +154,7 @@ DEFAULT_DATA = {
 def open_image(path: str, size: tuple = None, keep_aspect: bool = True, rotate: int = 0) -> ImageTk.PhotoImage:
     """
     Open the image on the path and apply given settings\n
-    Paramaters:
+    Parameters:
         path(str):
             Absolute path of the image
         size(tuple):
@@ -184,7 +184,7 @@ def save_data(data):
     """
     Saves given data as a .pkl (pickle) file
 
-    Paramters:
+    Parameters:
         data(dict):
             Dictionary containing all the necessary data to save
     """
@@ -596,7 +596,7 @@ class MainWindow(TkinterDnD.Tk):
                                relx=0, rely=0, relwidth=1, relheight=0)
 
     def fill_filePaths_Frame(self):
-        """Fill Frame with neccessary widgets"""
+        """Fill Frame with necessary widgets"""
         # -Create Widgets-
         # Save To Option
          # Select Music Files Option
@@ -636,7 +636,7 @@ class MainWindow(TkinterDnD.Tk):
 
 
     def fill_options_Frame(self):
-        """Fill Frame with neccessary widgets"""
+        """Fill Frame with necessary widgets"""
         # -Create Widgets-
       
 
@@ -2167,7 +2167,7 @@ class MainWindow(TkinterDnD.Tk):
             pass
 
     def open_newModel_filedialog(self):
-        """Let user paste an MDX-Net model to use for the vocal seperation"""
+        """Let user paste an MDX-Net model to use for the vocal separation"""
         
         filename = 'models\MDX_Net_Models'
 
@@ -3401,7 +3401,7 @@ class MainWindow(TkinterDnD.Tk):
             pyperclip.copy(copy_t)
             
     def open_Modelfolder_filedialog(self):
-        """Let user paste a ".pth" model to use for the vocal seperation"""
+        """Let user paste a ".pth" model to use for the vocal separation"""
         filename = 'models'
 
         if sys.platform == "win32":
@@ -3411,7 +3411,7 @@ class MainWindow(TkinterDnD.Tk):
             subprocess.call([opener, filename])
             
     def open_Modelfolder_vr(self):
-        """Let user paste a ".pth" model to use for the vocal seperation"""
+        """Let user paste a ".pth" model to use for the vocal separation"""
         filename = 'models\Main_Models'
 
         if sys.platform == "win32":
@@ -3421,7 +3421,7 @@ class MainWindow(TkinterDnD.Tk):
             subprocess.call([opener, filename])
             
     def open_Modelfolder_de(self):
-        """Let user paste a ".pth" model to use for the vocal seperation"""
+        """Let user paste a ".pth" model to use for the vocal separation"""
         filename = 'models\Demucs_Models'
 
         if sys.platform == "win32":

--- a/demucs/apply.py
+++ b/demucs/apply.py
@@ -156,7 +156,7 @@ def apply_model(model, mix, shifts=1, split=True,
     }
     if isinstance(model, BagOfModels):
         # Special treatment for bag of model.
-        # We explicitely apply multiple times `apply_model` so that the random shifts
+        # We explicitly apply multiple times `apply_model` so that the random shifts
         # are different for each model.
         estimates = 0
         totals = [0] * len(model.sources)

--- a/demucs/separate.py
+++ b/demucs/separate.py
@@ -174,7 +174,7 @@ def main():
             sources = list(sources)
             stem = str(track_folder / (args.stem + ext))
             save_audio(sources.pop(model.sources.index(args.stem)), stem, **kwargs)
-            # Warning : after poping the stem, selected stem is no longer in the list 'sources'
+            # Warning : after popping the stem, selected stem is no longer in the list 'sources'
             other_stem = th.zeros_like(sources[0])
             for i in sources:
                 other_stem += i

--- a/demucs/spec.py
+++ b/demucs/spec.py
@@ -3,7 +3,7 @@
 #
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
-"""Conveniance wrapper to perform STFT and iSTFT"""
+"""Convenience wrapper to perform STFT and iSTFT"""
 
 import torch as th
 

--- a/demucs/states.py
+++ b/demucs/states.py
@@ -57,7 +57,7 @@ def load_model(path_or_package, strict=False):
         sig = inspect.signature(klass)
         for key in list(kwargs):
             if key not in sig.parameters:
-                warnings.warn("Dropping inexistant parameter " + key)
+                warnings.warn("Dropping inexistent parameter " + key)
                 del kwargs[key]
         model = klass(*args, **kwargs)
 

--- a/demucs/wav.py
+++ b/demucs/wav.py
@@ -109,13 +109,13 @@ class Wavset:
             metadata (dict): output from `build_metadata`.
             sources (list[str]): list of source names.
             segment (None or float): segment length in seconds. If `None`, returns entire tracks.
-            shift (None or float): stride in seconds bewteen samples.
+            shift (None or float): stride in seconds between samples.
             normalize (bool): normalizes input audio, **based on the metadata content**,
                 i.e. the entire track is normalized, not individual extracts.
             samplerate (int): target sample rate. if the file sample rate
                 is different, it will be resampled on the fly.
             channels (int): target nb of channels. if different, will be
-                changed onthe fly.
+                changed on the fly.
             ext (str): extension for audio files (default is .wav).
 
         samplerate and channels are converted on the fly.

--- a/diffq/base.py
+++ b/diffq/base.py
@@ -174,25 +174,25 @@ class BaseQuantizer:
     def _bit_pack_param(self, qparam: _QuantizedParam, quantized: tp.Any,
                         pack_fn: tp.Any) -> tp.Any:
         """Further bitpack the quantized representation.
-        This is used to return the quantized state. Should be overriden.
+        This is used to return the quantized state. Should be overridden.
         """
         return quantized
 
     def _bit_unpack_param(self, qparam: _QuantizedParam, packed: tp.Any,
                           unpack_fn: tp.Any) -> tp.Any:
-        """Unpack bitpacked representation. Should be overriden
+        """Unpack bitpacked representation. Should be overridden
         """
         return packed
 
     def _quantize_param(self, qparam: _QuantizedParam) -> tp.Any:
         """
-        To be overriden.
+        To be overridden.
         """
         raise NotImplementedError()
 
     def _unquantize_param(self, qparam: _QuantizedParam, quantized: tp.Any) -> torch.Tensor:
         """
-        To be overriden.
+        To be overridden.
         """
         raise NotImplementedError()
 

--- a/diffq/diffq.py
+++ b/diffq/diffq.py
@@ -293,7 +293,7 @@ class DiffQuantizer(BaseQuantizer):
         return (all_packed, scales, packed_bits)
 
     def _bit_unpack_param(self, qparam, packed, unpack_fn):
-        """Unpack bitpacked representation. Should be overriden.
+        """Unpack bitpacked representation. Should be overridden.
         """
         packed_all_levels, scales, packed_bits = packed
         bits = unpack_fn(packed_bits, qparam.logit.numel()) + self.min_bits

--- a/diffq/lsq.py
+++ b/diffq/lsq.py
@@ -156,7 +156,7 @@ class LSQ(BaseQuantizer):
         return (packed, scale)
 
     def _bit_unpack_param(self, qparam, packed, unpack_fn):
-        """Unpack bitpacked representation. Should be overriden
+        """Unpack bitpacked representation. Should be overridden
         """
         packed_levels, scale = packed
         levels = unpack_fn(

--- a/diffq/ts_export.py
+++ b/diffq/ts_export.py
@@ -8,7 +8,7 @@ We have to do a lot of black magic for TorchScript to be happy
 because we cannot dynamically allocate new weights when loading the model.
 
 Here is how it works:
-- we generate code in a temporary python file for the given model that explicitely
+- we generate code in a temporary python file for the given model that explicitly
     override all the weights on the first forward from their packed version.
     This is because TorchScript does not let us iterate over parameters in a generic manner.
 - we zero out all the original weights. We cannot simply remove those weights
@@ -62,7 +62,7 @@ class DiffQTSModel(torch.nn.Module):
     def unpack(self):
         """
         Unpack the weights, automatically called on the first forward,
-        or explicitely."""
+        or explicitly."""
         if self._unpacked:
             return
 {unpack_assigns}

--- a/diffq/uniform.py
+++ b/diffq/uniform.py
@@ -108,7 +108,7 @@ class UniformQuantizer(BaseQuantizer):
         return (packed, scales)
 
     def _bit_unpack_param(self, qparam, packed, unpack_fn):
-        """Unpack bitpacked representation. Should be overriden
+        """Unpack bitpacked representation. Should be overridden
         """
         packed_levels, scales = packed
         levels = unpack_fn(

--- a/inference_MDX.py
+++ b/inference_MDX.py
@@ -640,7 +640,7 @@ class Predictor():
             except:
                 pass
         
-        widget_text.write(base_text + 'Completed Seperation!\n')
+        widget_text.write(base_text + 'Completed Separation!\n')
 
     def demix(self, mix):
         # 1 = demucs only

--- a/inference_v5.py
+++ b/inference_v5.py
@@ -425,7 +425,7 @@ def main(window: tk.Wm, text_widget: tk.Text, button_widget: tk.Button, progress
     timestampnum = round(datetime.utcnow().timestamp())
     randomnum = randrange(100000, 1000000)
 
-    # Separation Preperation
+    # Separation Preparation
     try:        #Load File(s)
                 for file_num, music_file in enumerate(data['input_paths'], start=1):
                         # Determine File Name
@@ -1048,7 +1048,7 @@ def main(window: tk.Wm, text_widget: tk.Text, button_widget: tk.Button, progress
                                 bin_image.tofile(f)
            
 
-                        text_widget.write(base_text + 'Completed Seperation!\n\n')
+                        text_widget.write(base_text + 'Completed Separation!\n\n')
     except Exception as e:
         traceback_text = ''.join(traceback.format_tb(e.__traceback__))
         message = f'Traceback Error: "{traceback_text}"\n{type(e).__name__}: "{e}"\n'

--- a/inference_v5_ensemble.py
+++ b/inference_v5_ensemble.py
@@ -313,7 +313,7 @@ class Predictor():
             except:
                 pass
         
-        widget_text.write(base_text + 'Completed Seperation!\n\n')
+        widget_text.write(base_text + 'Completed Separation!\n\n')
 
     def demix(self, mix):
         # 1 = demucs only
@@ -860,7 +860,7 @@ def main(window: tk.Wm, text_widget: tk.Text, button_widget: tk.Button, progress
 
     print('Do all of the HP models exist? ' + hp2_ens)
 
-    # Separation Preperation
+    # Separation Preparation
     try:    #Ensemble Dictionary
 
         overlap_set = float(data['overlap'])
@@ -2118,7 +2118,7 @@ def main(window: tk.Wm, text_widget: tk.Text, button_widget: tk.Button, progress
                                         _, bin_image = cv2.imencode('.jpg', image)
                                         bin_image.tofile(f)
                                         
-                                text_widget.write(base_text + 'Completed Seperation!\n\n')  
+                                text_widget.write(base_text + 'Completed Separation!\n\n')  
                     
 
                             if data['ensChoose'] == 'Multi-AI Ensemble':
@@ -2577,7 +2577,7 @@ def main(window: tk.Wm, text_widget: tk.Text, button_widget: tk.Button, progress
                             os.chdir(path)
                             audio_files = os.listdir()
                             for file in audio_files:
-                                #spliting the file into the name and the extension
+                                #splitting the file into the name and the extension
                                 name, ext = os.path.splitext(file)
                                 if ext == ".wav":
                                     if trackname in file:
@@ -2634,7 +2634,7 @@ def main(window: tk.Wm, text_widget: tk.Text, button_widget: tk.Button, progress
                             os.chdir(path)
                             audio_files = os.listdir()
                             for file in audio_files:
-                                #spliting the file into the name and the extension
+                                #splitting the file into the name and the extension
                                 name, ext = os.path.splitext(file)
                                 if ext == ".wav":
                                     if trackname in file:

--- a/lib_v5/spec_utils.py
+++ b/lib_v5/spec_utils.py
@@ -113,7 +113,7 @@ def combine_spectrograms(specs, mp):
     if offset > mp.param['bins']:
         raise ValueError('Too much bins')
         
-    # lowpass fiter
+    # lowpass filter
     if mp.param['pre_filter_start'] > 0: # and mp.param['band'][bands_n]['res_type'] in ['scipy', 'polyphase']:   
         if bands_n == 1:
             spec_c = fft_lp_filter(spec_c, mp.param['pre_filter_start'], mp.param['pre_filter_stop'])

--- a/tkinterdnd2/TkinterDnD.py
+++ b/tkinterdnd2/TkinterDnD.py
@@ -238,7 +238,7 @@ class DnDWrapper:
 
     def platform_independent_types(self, *dndtypes):
         '''This command will accept a list of types that can contain platform
-        independnent or platform specific types. A new list will be returned,
+        independent or platform specific types. A new list will be returned,
         where each platform specific type in DNDTYPES will be substituted by
         one or more platform independent types. Thus, the returned list may
         have more elements than DNDTYPES.'''
@@ -248,7 +248,7 @@ class DnDWrapper:
 
     def platform_specific_types(self, *dndtypes):
         '''This command will accept a list of types that can contain platform
-        independnent or platform specific types. A new list will be returned,
+        independent or platform specific types. A new list will be returned,
         where each platform independent type in DNDTYPES will be substituted
         by one or more platform specific types. Thus, the returned list may
         have more elements than DNDTYPES.'''


### PR DESCRIPTION
[`codespell --ignore-words-list=activ,fo,nin,ot,trough`](https://pypi.org/project/codespell)