### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ opencv-python==4.6.0.66
 onnx
 onnxruntime==1.13.1
 Pillow==9.3.0
-pip==22.2.2
+pip
 playsound==1.3.0
 psutil==5.9.4
 pydub==0.25.1
@@ -38,5 +38,3 @@ urllib3==1.26.12
 wget==3.2
 samplerate==0.1.0
 screeninfo==0.8.1
-PySoundFile==0.9.0.post1; sys_platform != 'windows'
-SoundFile==0.9.0; sys_platform == 'windows'


### PR DESCRIPTION
Forcing a version requirement for pip essentially forces a downgrade. Not only is this annoying, it is entirely unnecessary.

Additionally, the requirement to install soundfile 0.11.0 is in direct conflict with the later attempts to install 0.9.0 on lines 41/42...and the sys_platform value is incorrect to begin with. It should be `win32` - not `windows`. soundfile 0.11.0 works fine on Windows.

This commit actually makes requirements.txt work properly...