### PR TITLE
fix(sec): upgrade certifi to 2023.7.22

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 altgraph==0.17.3
 audioread==3.0.0
-certifi==2022.12.07
+certifi==2023.7.22
 cffi==1.15.1
 cryptography==3.4.6
 einops==0.6.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in certifi 2022.12.07
- [CVE-2023-37920](https://www.oscs1024.com/hd/CVE-2023-37920)


### What did I do？
Upgrade certifi from 2022.12.07 to 2023.7.22 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS