### PR TITLE
Make lastDir actually work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+__pycache__
+
+data.pkl
+gui_data/cr_text.txt

--- a/UVR.py
+++ b/UVR.py
@@ -2134,7 +2134,8 @@ class MainWindow(TkinterDnD.Tk if is_dnd_compatible else tk.Tk):
         
         if dialoge_type == MULTIPLE_FILE:
             filenames = filedialog.askopenfilenames(parent=parent_win, 
-                                                    title=text)
+                                                    title=text,
+                                                    initialdir=lastDir)
         elif dialoge_type == MAIN_MULTIPLE_FILE:
             filenames = filedialog.askopenfilenames(parent=parent_win, 
                                                     title=text,
@@ -2142,17 +2143,32 @@ class MainWindow(TkinterDnD.Tk if is_dnd_compatible else tk.Tk):
                                                     initialdir=lastDir)
         elif dialoge_type == SINGLE_FILE:
             filenames = filedialog.askopenfilename(parent=parent_win, 
-                                                   title=text)
+                                                   title=text,
+                                                   initialdir=lastDir)
         elif dialoge_type == CHOOSE_EXPORT_DIR:
             filenames = filedialog.askdirectory(
                                     parent=parent_win,
-                                    title=f'Select Folder',)
+                                    title=f'Select Folder',
+                                    initialdir=lastDir)
             
         if is_linux:
             print("Is Linux")
             self.linux_filebox_fix(False)
             top.destroy()
             
+
+        # save the last dir
+        if isinstance(filenames, tuple):
+            some_path = filenames[0]
+        else:
+            some_path = filenames
+
+        if some_path is not None:
+            if os.path.isdir(some_path):
+                self.lastDir[dialoge_type] = some_path
+            elif os.path.isdir(os.path.dirname(some_path)):
+                self.lastDir[dialoge_type] = os.path.dirname(some_path)
+
         return filenames
 
     def input_select_filedialog(self):
@@ -6774,7 +6790,7 @@ class MainWindow(TkinterDnD.Tk if is_dnd_compatible else tk.Tk):
         self.inputPaths = data['input_paths']
         self.lastDir = data['lastDir']
 
-        if not instanceof(self.lastDir, dict):
+        if not isinstance(self.lastDir, dict):
             self.lastDir = {dt: self.lastDir for dt in DIALOGUE_TYPES}
         
         #DualPaths-Align

--- a/UVR.py
+++ b/UVR.py
@@ -2247,6 +2247,12 @@ class MainWindow(TkinterDnD.Tk if is_dnd_compatible else tk.Tk):
         if confirm:
             self.save_values(app_close=True, is_restart=True)
         
+
+    def quit(self):
+        self.save_values(app_close=True)
+        super().quit()
+
+
     def delete_temps(self, is_start_up=False):  
         """Deletes temp files"""
         
@@ -7194,6 +7200,11 @@ if __name__ == "__main__":
     root.update_checkbox_text()
     root.is_root_defined_var.set(True)
     root.is_check_splash = True
+
+    # macOS - intercept the Quit event to make sure we save our preferences
+    # the default implementation completely shortcuts python and directly exits the process
+    # even atexit handlers are not called!
+    root.createcommand('tk::mac::Quit', root.quit)
 
     root.update() if is_windows else root.update_idletasks()
     root.deiconify()

--- a/UVR.py
+++ b/UVR.py
@@ -2122,6 +2122,8 @@ class MainWindow(TkinterDnD.Tk if is_dnd_compatible else tk.Tk):
     def show_file_dialog(self, text='Select Audio files', dialoge_type=None):
         parent_win = root
         is_linux = not is_windows and not is_macos
+
+        lastDir = self.lastDir.get(dialoge_type)
         
         if is_linux:
             self.linux_filebox_fix()
@@ -2137,11 +2139,11 @@ class MainWindow(TkinterDnD.Tk if is_dnd_compatible else tk.Tk):
             filenames = filedialog.askopenfilenames(parent=parent_win, 
                                                     title=text,
                                                     initialfile='',
-                                                    initialdir=self.lastDir)
+                                                    initialdir=lastDir)
         elif dialoge_type == SINGLE_FILE:
             filenames = filedialog.askopenfilename(parent=parent_win, 
                                                    title=text)
-        elif dialoge_type == CHOOSE_EXPORT_FIR:
+        elif dialoge_type == CHOOSE_EXPORT_DIR:
             filenames = filedialog.askdirectory(
                                     parent=parent_win,
                                     title=f'Select Folder',)
@@ -2156,10 +2158,6 @@ class MainWindow(TkinterDnD.Tk if is_dnd_compatible else tk.Tk):
     def input_select_filedialog(self):
         """Make user select music files"""
 
-        if self.lastDir is not None:
-            if not os.path.isdir(self.lastDir):
-                self.lastDir = None
-
         paths = self.show_file_dialog(dialoge_type=MAIN_MULTIPLE_FILE)
 
         if paths:  # Path selected
@@ -2173,7 +2171,7 @@ class MainWindow(TkinterDnD.Tk if is_dnd_compatible else tk.Tk):
 
         export_path = None
         
-        path = self.show_file_dialog(dialoge_type=CHOOSE_EXPORT_FIR)
+        path = self.show_file_dialog(dialoge_type=CHOOSE_EXPORT_DIR)
 
         if path:  # Path selected
             self.export_path_var.set(path)
@@ -6775,6 +6773,9 @@ class MainWindow(TkinterDnD.Tk if is_dnd_compatible else tk.Tk):
         self.export_path_var = tk.StringVar(value=data['export_path'])
         self.inputPaths = data['input_paths']
         self.lastDir = data['lastDir']
+
+        if not instanceof(self.lastDir, dict):
+            self.lastDir = {dt: self.lastDir for dt in DIALOGUE_TYPES}
         
         #DualPaths-Align
         self.time_window_var = tk.StringVar(value=data['time_window'])#

--- a/UVR.py
+++ b/UVR.py
@@ -2258,6 +2258,7 @@ class MainWindow(TkinterDnD.Tk if is_dnd_compatible else tk.Tk):
         
         DIRECTORIES = (BASE_PATH, VR_MODELS_DIR, MDX_MODELS_DIR, DEMUCS_MODELS_DIR, DEMUCS_NEWER_REPO_DIR)
         EXTENSIONS = (('.aes', '.txt', '.tmp'))
+        EXCEPTIONS = {'requirements.txt', 'demucs_models.txt'}
         
         try:
             if os.path.isfile(f"{current_patch}{application_extension}"):
@@ -2267,11 +2268,11 @@ class MainWindow(TkinterDnD.Tk if is_dnd_compatible else tk.Tk):
                 if os.path.isfile(SPLASH_DOC):
                     os.remove(SPLASH_DOC)
             
-            for dir in DIRECTORIES:
-                for temp_file in os.listdir(dir):
-                    if temp_file.endswith(EXTENSIONS):
-                        if os.path.isfile(os.path.join(dir, temp_file)):
-                            os.remove(os.path.join(dir, temp_file))
+            for directory in DIRECTORIES:
+                for temp_file in os.listdir(directory):
+                    if temp_file.endswith(EXTENSIONS) and temp_file not in EXCEPTIONS:
+                        if os.path.isfile(os.path.join(directory, temp_file)):
+                            os.remove(os.path.join(directory, temp_file))
         except Exception as e:
             self.error_log_var.set(error_text(TEMP_FILE_DELETION_TEXT, e))
         

--- a/demucs/pretrained.py
+++ b/demucs/pretrained.py
@@ -10,8 +10,6 @@ import logging
 from pathlib import Path
 import typing as tp
 
-#from dora.log import fatal
-
 import logging
 
 from diffq import DiffQuantizer

--- a/gui_data/constants.py
+++ b/gui_data/constants.py
@@ -26,7 +26,9 @@ ALIGNMENT_TOOL = 'Alignment Tool Options'
 SINGLE_FILE = 'SINGLE_FILE'
 MULTIPLE_FILE = 'MULTI_FILE'
 MAIN_MULTIPLE_FILE = 'MAIN_MULTI_FILE'
-CHOOSE_EXPORT_FIR = 'CHOOSE_EXPORT_FIR'
+CHOOSE_EXPORT_DIR = 'CHOOSE_EXPORT_DIR'
+
+DIALOGUE_TYPES = (SINGLE_FILE, MULTIPLE_FILE, MAIN_MULTIPLE_FILE, CHOOSE_EXPORT_DIR)
 
 DUAL = "dual"
 FOUR_STEM = "fourstem"
@@ -647,7 +649,7 @@ DEFAULT_DATA = {
         'user_code': '',
         'export_path': '',
         'input_paths': [],
-        'lastDir': None,
+        'lastDir': {},
         'time_window': "3",
         'intro_analysis': "Default",
         'db_analysis': "Medium",

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,5 +37,4 @@ onnxruntime
 onnx2pytorch
 SoundFile==0.11.0; sys_platform != 'darwin'
 PySoundFile==0.9.0.post1; sys_platform == 'darwin'
-Dora==0.0.3
 numpy==1.23.5


### PR DESCRIPTION
lastDir currently is never populated and the output dialogue always defaults to the system root. This patch:

* Stores and fetches the last directory the user selected for each open/save dialogue type
* Fixes saving app data on exit on macOS
* Adds some quality-of-life improvements for developers