### PR TITLE
fix pip install error and run error

### DIFF
--- a/gui_data/app_size_values.py
+++ b/gui_data/app_size_values.py
@@ -132,9 +132,9 @@ class ImagePath():
         if size is not None:
             size = (int(size[0]), int(size[1]))
             if keep_aspect:
-                img = img.resize((size[0], int(size[0] * ratio)), Image.ANTIALIAS)
+                img = img.resize((size[0], int(size[0] * ratio)), Image.Resampling.LANCZOS)
             else:
-                img = img.resize(size, Image.ANTIALIAS)
+                img = img.resize(size, Image.Resampling.LANCZOS)
                 
         return ImageTk.PhotoImage(img)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ pyrubberband==0.3.0
 pytorch_lightning==2.0.0
 PyYAML==6.0
 resampy==0.4.2
-scipy==1.9.3
+scipy>=1.9.3
 soundstretch==1.2
 torch
 urllib3==1.26.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,3 +50,4 @@ spafe==0.3.2
 protobuf==3.20.3
 torch_audiomentations
 asteroid==0.7.0
+chardet


### PR DESCRIPTION
Fix the following error UVR can run normally after `git clone` and `pip install -r requirements.txt`

## pip install error

```
INFO: pip is looking at multiple versions of asteroid to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install -r .\requirements.txt (line 10), -r .\requirements.txt (line 12), -r .\requirements.txt (line 27), -r .\requirements.txt (line 41), -r .\requirements.txt (line 45), -r .\requirements.txt (line 49), -r .\requirements.txt (line 52) and scipy==1.9.3 because these package versions have con
flicting dependencies.

The conflict is caused by:
    The user requested scipy==1.9.3
    librosa 0.9.2 depends on scipy>=1.2.0
    matchering 2.0.6 depends on scipy>=1.9.2
    soundstretch 1.2 depends on scipy
    dora 0.0.3 depends on scipy>=0.17.0
    audiomentations 0.24.0 depends on scipy<2 and >=1.0.0
    spafe 0.3.2 depends on scipy>=1.7.3
    asteroid 0.7.0 depends on scipy>=1.10.1

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
```

## Pillow>10 new version: 'PIL.IMAGE' has no attribute 'ANTIALIAS'
```
Traceback (most recent call last):
  File "\ultimatevocalremovergui\UVR.py", line 7288, in <module>
    root = MainWindow()
  File "\ultimatevocalremovergui\UVR.py", line 1350, in __init__
    img = ImagePath(BASE_PATH)
  File "\ultimatevocalremovergui\gui_data\app_size_values.py", line 95, in __init__
    self.efile_img = self.open_image(path=efile_path,size=(image_scale_1, image_scale_1))
  File "\ultimatevocalremovergui\gui_data\app_size_values.py", line 135, in open_image
    img = img.resize((size[0], int(size[0] * ratio)), Image.ANTIALIAS)
AttributeError: module 'PIL.Image' has no attribute 'ANTIALIAS'
```

## huggingface_hub  error
```
from huggingface_hub import get_full_repo_name  # for backward compatibility
ImportError: cannot import name 'get_full_repo_name' from 'huggingface_hub' 
```
