### PR TITLE
Fix "Audio buffer is not finite everywhere" by force initializing buffer for spec_s

### DIFF
--- a/lib_v5/spec_utils.py
+++ b/lib_v5/spec_utils.py
@@ -312,7 +312,7 @@ def cmb_spectrogram_to_wave(spec_m, mp, extra_bins_h=None, extra_bins=None, is_v
 
     for d in range(1, bands_n + 1):
         bp = mp.param['band'][d]
-        spec_s = np.ndarray(shape=(2, bp['n_fft'] // 2 + 1, spec_m.shape[2]), dtype=complex)
+        spec_s = np.zeros(shape=(2, bp['n_fft'] // 2 + 1, spec_m.shape[2]), dtype=complex)
         h = bp['crop_stop'] - bp['crop_start']
         spec_s[:, bp['crop_start']:bp['crop_stop'], :] = spec_m[:, offset:offset+h, :]
                 


### PR DESCRIPTION
Initializing spec_s with np.ndarray can contain Nan / Inf according to the [numpy docs](https://numpy.org/doc/1.23/reference/generated/numpy.ndarray.html), since it does not overwrite the underlying buffer memory. This causes the "Audio buffer is not finite everywhere" error in _cmb_spectrogram_to_wave,_ as already reported in multiple issues (#1021, #1045, #1147, #1153, #1262, to name a few). Initializing with np.zeros populates the buffer with zeros, avoiding the issue.