### PR TITLE
Fix Demucs model loading

### DIFF
--- a/demucs/states.py
+++ b/demucs/states.py
@@ -43,7 +43,7 @@ def load_model(path_or_package, strict=False):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             path = path_or_package
-            package = torch.load(path, 'cpu')
+            package = torch.load(path, 'cpu',weights_only=False)
     else:
         raise ValueError(f"Invalid type for {path_or_package}.")
 


### PR DESCRIPTION
Due to torch's changes, it made loading weights_only, which made loading of demucs fail, this is fixed by setting weights_only to False.