### PR TITLE
Add Apple Silicon MPS inference backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# macOS AppleDouble metadata files.
+._*
+
+# Local build and packaging outputs.
+.venv-build-macos/
+.venv-smoke/
+.research-artifacts/
+build/
+dist/
+*.dmg
+*.spec.bak
+
+# Downloaded model weights are runtime/user assets, not source.
+models/**/*.pth
+models/**/*.onnx
+models/**/*.ckpt
+models/**/*.th
+models/Demucs_Models/v3_v4_repo/htdemucs.yaml
+
+# Python/PyInstaller caches.
+__pycache__/
+*.pyc
+*.pyo
+*.log

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ In order to use the Time Stretch or Change Pitch tool, you'll need Rubber Band.
 ### MacOS Installation
 - Please Note:
     - The MacOS Sonoma mouse clicking issue has been fixed.
-    - MPS (GPU) acceleration for Mac M1 has been expanded to work with Demucs v4 and all MDX-Net models.
+    - Apple Silicon GPU acceleration is available through MPS. Some model paths may fall back to CPU when PyTorch or the selected backend cannot run an operation on Apple GPU.
     - This bundle is intended for those running macOS Big Sur and above.
     - Application functionality for systems running macOS Catalina or lower is not guaranteed.
     - Application functionality for older or budget Mac systems is not guaranteed.
@@ -235,9 +235,10 @@ If you encounter issues, refer to the [GitHub Issues](https://github.com/Anjok07
 ### Other Application Notes
 - Nvidia GTX 1060 6GB is the minimum requirement for GPU conversions.
 - Nvidia GPUs with at least 8GBs of V-RAM are recommended.
+- Apple Silicon Macs can use Apple GPU (MPS) acceleration when running a modern PyTorch build with MPS support.
 - AMD Radeon GPU supported is limited at this time.
    - There is currently a working branch for AMD GPU users [here](https://github.com/Anjok07/ultimatevocalremovergui/tree/v5.6-amd-gpu)
-- This application is only compatible with 64-bit platforms. 
+- This application is only compatible with 64-bit platforms.
 - This application relies on the Rubber Band library for the Time-Stretch and Pitch-Shift options.
 - This application relies on FFmpeg to process non-wav audio files.
 - The application will automatically remember your settings when closed.
@@ -247,6 +248,101 @@ If you encounter issues, refer to the [GitHub Issues](https://github.com/Anjok07
 ### Performance:
 - Model load times are faster.
 - Importing/exporting audio files is faster.
+
+## Inference Backends
+
+UVR now uses an inference backend selector behind the existing GPU controls. The available backend modes are:
+
+- `Auto`
+- `CPU`
+- `CUDA`
+- `Apple GPU (MPS)`
+- `CoreML`
+
+`Auto` prefers CUDA first, then Apple GPU (MPS), then CoreML for ONNX models on macOS, then CPU. On macOS Apple Silicon, the settings UI shows the relevant choices: `Auto`, `Apple GPU (MPS)`, `CoreML`, and `CPU`.
+
+Backend coverage:
+
+- VR and MDXC models run through PyTorch and can use CPU, CUDA, or Apple GPU (MPS).
+- MDX ONNX models keep ONNX Runtime CUDA and CPU support. On Apple GPU (MPS), MDX ONNX models are converted through `onnx2pytorch` and run as PyTorch models. `CoreML` is available as an explicit experimental ONNX Runtime backend.
+- Demucs v3 and v4 can attempt Apple GPU (MPS). If that path fails, UVR falls back to CPU and records the fallback in the log. Demucs v1 and v2 keep the older CPU/CUDA behavior by default.
+
+The conversion log includes the selected backend, runner, model load time, and fallback status. `PYTORCH_ENABLE_MPS_FALLBACK=1` is set by default for compatibility, but the primary MPS paths are expected to work without hiding unsupported device transfers.
+
+## Developer Smoke Tests
+
+The real-model smoke harness lives in `tools/smoke_inference.py`. It intentionally avoids importing `UVR.py` because `UVR.py` starts the tkinter mainloop on import. The harness drives the separator classes directly, writes results to `.research-artifacts/smoke/smoke_results.jsonl`, and keeps generated audio under `.research-artifacts/smoke/`.
+
+Recommended Apple Silicon setup:
+
+```bash
+uv python install 3.10
+uv venv .venv-smoke --python 3.10
+.venv-smoke/bin/python -m ensurepip --upgrade
+.venv-smoke/bin/python -m pip install playsound==1.2.2
+SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True .venv-smoke/bin/python -m pip install -r requirements.txt
+.venv-smoke/bin/python -m pip uninstall -y PySoundFile
+.venv-smoke/bin/python -m pip install soundfile==0.13.1 onnx2pytorch
+```
+
+Run the blocking smoke flow:
+
+```bash
+.venv-smoke/bin/python tools/smoke_inference.py prepare
+.venv-smoke/bin/python tools/smoke_inference.py doctor --append
+.venv-smoke/bin/python tools/smoke_inference.py probe --append
+.venv-smoke/bin/python tools/smoke_inference.py run --phase blocking --continue-on-error --append
+.venv-smoke/bin/python tools/smoke_inference.py summary --append
+```
+
+The blocking phase covers backend probing plus single-model real inference for VR, MDX ONNX, MDX ONNX CoreML, MDXC, and Demucs v4. Additional phases are available for release checks:
+
+- `extended`: secondary model, vocal splitter, ensemble, FLAC output, and MP3 output.
+- `backend_modes`: explicit Apple GPU (MPS) cases and Demucs v4 CPU comparison.
+- `gpu_disabled`: verifies that disabling GPU forces CPU even when Auto or MPS is selected.
+- `demucs_legacy`: verifies Demucs v1/v2 backend policy without requiring legacy weights.
+- `format_inputs`: FLAC input, MP3 input, and mono input.
+- `long_audio`: 60-second MDX MPS and 180-second VR CPU stability checks.
+- `all`: blocking, extended, backend mode, GPU-disabled, Demucs legacy, format-input, and long-audio checks.
+
+Use `summary` after a run to print the latest pass/fail state and CPU-vs-MPS timing pairs.
+
+The `prepare` command downloads the minimal real model set into the app's existing model folders and generates an 8-second stereo WAV input. Do not commit `.venv-smoke`, `.research-artifacts`, downloaded model weights, `__pycache__`, or AppleDouble `._*` files.
+
+### MDX23C Apple GPU Functional Check
+
+A full-length MDX23C functional check was run on Apple Silicon with the packaged app resources:
+
+- Model: `dist/Ultimate Vocal Remover.app/Contents/Resources/models/MDX_Net_Models/MDX23C-8KFFT-InstVoc_HQ.ckpt`
+- Input: `example_data/kamiina_ep01.wav`
+- Config: `model_2_stem_full_band_8k.yaml`
+- Backend mode: `Auto`
+- Actual backend: `Apple GPU (MPS)`
+- Torch device: `mps`
+- Fallback: `false`
+- Result: `passed`
+- Elapsed time: `2070.068s`
+
+The model hash did not match an entry in the bundled `model_data.json`, so the GUI does not automatically infer its MDX23C config from metadata. For this file, use the 8KFFT config `model_2_stem_full_band_8k.yaml`.
+
+The effective MDX23C parameters for that check were:
+
+- Segment size: `256`
+- Segment default: `true`, so `inference.dim_t=256` from the config was used.
+- Overlap: `8`
+- Batch size: `1`
+- `n_fft`: `8192`
+- `dim_f`: `4096`
+- `hop_length`: `1024`
+- Runtime chunk size: `1024 * (256 - 1) = 261120`
+- Runtime hop size: `261120 // 8 = 32640`
+- Instruments: `Vocals`, `Instrumental`
+- Output format: WAV `PCM_16`
+- Output normalization: `false`
+- Pitch shift: `0`
+- Match frequency cutoff: `true`, but it is not used when pitch shift is zero.
+
+The generated verification files live under `.research-artifacts/functional-mdxc-app/` and are intentionally not committed.
 
 ## Troubleshooting
 

--- a/UVR.py
+++ b/UVR.py
@@ -9,6 +9,7 @@ import librosa
 import math
 import natsort
 import os
+os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
 import pickle
 import psutil
 from pyglet import font as pyglet_font
@@ -44,6 +45,7 @@ from lib_v5.vr_network.model_param_init import ModelParameters
 from kthread import KThread
 from lib_v5 import spec_utils
 from pathlib  import Path
+from inference_backend import BACKEND_MODE_OPTIONS as INFERENCE_BACKEND_MODE_OPTIONS
 from separate import (
     SeperateDemucs, SeperateMDX, SeperateMDXC, SeperateVR,  # Model-related
     save_format, clear_gpu_cache,  # Utility functions
@@ -345,6 +347,7 @@ class ModelData():
         self.deverb_vocal_opt = DEVERB_MAPPER[root.deverb_vocal_opt_var.get()]
         self.is_denoise_model = True if root.denoise_option_var.get() == DENOISE_M and os.path.isfile(DENOISER_MODEL_PATH) else False
         self.is_gpu_conversion = 0 if root.is_gpu_conversion_var.get() else -1
+        self.backend_mode = root.backend_mode_var.get()
         self.is_normalization = root.is_normalization_var.get()#
         self.is_use_opencl = False#True if is_opencl_only else root.is_use_opencl_var.get()
         self.is_primary_stem_only = root.is_primary_stem_only_var.get()
@@ -3174,6 +3177,8 @@ class MainWindow(TkinterDnD.Tk if is_dnd_compatible else tk.Tk):
                 self.cuda_device_list = [f"{torch.cuda.get_device_properties(i).name}:{i}" for i in range(torch.cuda.device_count())]
                 self.cuda_device_list.insert(0, DEFAULT)
                 #print(self.cuda_device_list)
+            elif mps_available:
+                self.cuda_device_list = [DEFAULT]
             
             # if directml_available:
             #     self.opencl_list = [f"{torch_directml.device_name(i)}:{i}" for i in range(torch_directml.device_count())]
@@ -3337,6 +3342,19 @@ class MainWindow(TkinterDnD.Tk if is_dnd_compatible else tk.Tk):
 
         #if not is_choose_arch:
         self.vocal_splitter_Button_opt(settings_menu, settings_menu_format_Frame, width=SETTINGS_BUT_WIDTH-2, pady=MENU_PADDING_4)
+
+        if self.is_gpu_available:
+            backend_Label = self.menu_title_LABEL_SET(settings_menu_format_Frame, BACKEND_MODE_TEXT)
+            backend_Label.grid(pady=MENU_PADDING_2)
+
+            backend_options = (
+                (BACKEND_AUTO, BACKEND_MPS, BACKEND_COREML, BACKEND_CPU)
+                if is_macos else
+                INFERENCE_BACKEND_MODE_OPTIONS
+            )
+            backend_Option = ComboBoxMenu(settings_menu_format_Frame, textvariable=self.backend_mode_var, values=backend_options, width=GEN_SETTINGS_WIDTH+1)
+            backend_Option.grid(padx=20,pady=MENU_PADDING_1)
+            self.help_hints(backend_Label, text=BACKEND_MODE_HELP)
 
         if not is_macos and self.is_gpu_available:
             gpu_list_options = lambda:self.loop_gpu_list(device_set_Option, 'gpudevice', self.cuda_device_list)#self.opencl_list if is_opencl_only or self.is_use_opencl_var.get() else self.cuda_device_list)
@@ -6823,7 +6841,8 @@ class MainWindow(TkinterDnD.Tk if is_dnd_compatible else tk.Tk):
         self.save_format_var = tk.StringVar(value=data['save_format'])
         self.wav_type_set_var = tk.StringVar(value=data['wav_type_set'])#
         self.device_set_var = tk.StringVar(value=data['device_set'])#
-        self.user_code_var = tk.StringVar(value=data['user_code']) 
+        self.backend_mode_var = tk.StringVar(value=data['backend_mode'])
+        self.user_code_var = tk.StringVar(value=data['user_code'])
         self.is_gpu_conversion_var = tk.BooleanVar(value=data['is_gpu_conversion'])
         self.is_primary_stem_only_var = tk.BooleanVar(value=data['is_primary_stem_only'])
         self.is_secondary_stem_only_var = tk.BooleanVar(value=data['is_secondary_stem_only'])
@@ -6967,6 +6986,7 @@ class MainWindow(TkinterDnD.Tk if is_dnd_compatible else tk.Tk):
             self.save_format_var.set(loaded_setting['save_format'])
             self.wav_type_set_var.set(loaded_setting['wav_type_set'])#
             self.device_set_var.set(loaded_setting['device_set'])#
+            self.backend_mode_var.set(loaded_setting['backend_mode'])
             self.user_code_var.set(loaded_setting['user_code'])
             self.phase_option_var.set(loaded_setting['phase_option'])#
             self.phase_shifts_var.set(loaded_setting['phase_shifts'])#
@@ -6983,6 +7003,7 @@ class MainWindow(TkinterDnD.Tk if is_dnd_compatible else tk.Tk):
             self.DualBatch_inputPaths = []
             
         self.is_gpu_conversion_var.set(loaded_setting['is_gpu_conversion'])
+        self.backend_mode_var.set(loaded_setting['backend_mode'])
         self.is_normalization_var.set(loaded_setting['is_normalization'])#
         self.is_use_opencl_var.set(False)#True if is_opencl_only else loaded_setting['is_use_opencl'])#
         self.is_wav_ensemble_var.set(loaded_setting['is_wav_ensemble'])#
@@ -7087,6 +7108,7 @@ class MainWindow(TkinterDnD.Tk if is_dnd_compatible else tk.Tk):
             'pitch_rate': self.pitch_rate_var.get(),#
             'is_time_correction': self.is_time_correction_var.get(),#
             'is_gpu_conversion': self.is_gpu_conversion_var.get(),
+            'backend_mode': self.backend_mode_var.get(),
             'is_primary_stem_only': self.is_primary_stem_only_var.get(),
             'is_secondary_stem_only': self.is_secondary_stem_only_var.get(),
             'is_testing_audio': self.is_testing_audio_var.get(),#

--- a/demucs/hdemucs.py
+++ b/demucs/hdemucs.py
@@ -770,27 +770,23 @@ class HDemucs(nn.Module):
         x = x.view(B, S, -1, Fq, T)
         x = x * std[:, None] + mean[:, None]
         
-        # to cpu as non-cuda GPUs don't support complex numbers
-        # demucs issue #435 ##432
-        # NOTE: in this case z already is on cpu
-        # TODO: remove this when mps supports complex numbers
-        
-        device_type = x.device.type
-        device_load = f"{device_type}:{x.device.index}" if not device_type == 'mps' else device_type
-        x_is_other_gpu = not device_type in ["cuda", "cpu"]
-        
-        if x_is_other_gpu:
-            x = x.cpu()
-
-        zout = self._mask(z, x)
-        x = self._ispec(zout, length)
-
-        # back to other device
-        if x_is_other_gpu:
-            x = x.to(device_load)
+        device = x.device
+        device_type = device.type
+        try:
+            zout = self._mask(z, x)
+            x = self._ispec(zout, length)
+        except Exception:
+            if device_type in ["cuda", "cpu"]:
+                raise
+            if self.hybrid:
+                xt = xt.cpu()
+                meant = meant.cpu()
+                stdt = stdt.cpu()
+            zout = self._mask(z.cpu(), x.cpu())
+            x = self._ispec(zout, length)
 
         if self.hybrid:
             xt = xt.view(B, S, -1, length)
             xt = xt * stdt[:, None] + meant[:, None]
             x = xt + x
-        return x
+        return x.to(device) if x.device != device else x

--- a/demucs/htdemucs.py
+++ b/demucs/htdemucs.py
@@ -625,30 +625,31 @@ class HTDemucs(nn.Module):
         x = x.view(B, S, -1, Fq, T)
         x = x * std[:, None] + mean[:, None]
 
-        # to cpu as non-cuda GPUs don't support complex numbers
-        # demucs issue #435 ##432
-        # NOTE: in this case z already is on cpu
-        # TODO: remove this when mps supports complex numbers
-        
-        device_type = x.device.type
-        device_load = f"{device_type}:{x.device.index}" if not device_type == 'mps' else device_type
-        x_is_other_gpu = not device_type in ["cuda", "cpu"]
-        
-        if x_is_other_gpu:
-            x = x.cpu()
-
-        zout = self._mask(z, x)
-        if self.use_train_segment:
-            if self.training:
-                x = self._ispec(zout, length)
+        device = x.device
+        device_type = device.type
+        try:
+            zout = self._mask(z, x)
+            if self.use_train_segment:
+                if self.training:
+                    x = self._ispec(zout, length)
+                else:
+                    x = self._ispec(zout, training_length)
             else:
-                x = self._ispec(zout, training_length)
-        else:
-            x = self._ispec(zout, length)
-
-        # back to other device
-        if x_is_other_gpu:
-            x = x.to(device_load)
+                x = self._ispec(zout, length)
+        except Exception:
+            if device_type in ["cuda", "cpu"]:
+                raise
+            xt = xt.cpu()
+            meant = meant.cpu()
+            stdt = stdt.cpu()
+            zout = self._mask(z.cpu(), x.cpu())
+            if self.use_train_segment:
+                if self.training:
+                    x = self._ispec(zout, length)
+                else:
+                    x = self._ispec(zout, training_length)
+            else:
+                x = self._ispec(zout, length)
 
         if self.use_train_segment:
             if self.training:
@@ -659,6 +660,7 @@ class HTDemucs(nn.Module):
             xt = xt.view(B, S, -1, length)
         xt = xt * stdt[:, None] + meant[:, None]
         x = xt + x
+        x = x.to(device) if x.device != device else x
         if length_pre_pad:
             x = x[..., :length_pre_pad]
         return x

--- a/demucs/spec.py
+++ b/demucs/spec.py
@@ -11,21 +11,33 @@ import torch as th
 def spectro(x, n_fft=512, hop_length=None, pad=0):
     *other, length = x.shape
     x = x.reshape(-1, length)
-    
-    device_type = x.device.type
-    is_other_gpu = not device_type in ["cuda", "cpu"]
-
-    if is_other_gpu:
+    original_device = x.device
+    try:
+        z = th.stft(x,
+                    n_fft * (1 + pad),
+                    hop_length or n_fft // 4,
+                    window=th.hann_window(n_fft).to(x),
+                    win_length=n_fft,
+                    normalized=True,
+                    center=True,
+                    return_complex=True,
+                    pad_mode='reflect')
+    except Exception:
         x = x.cpu()
-    z = th.stft(x,
-                n_fft * (1 + pad),
-                hop_length or n_fft // 4,
-                window=th.hann_window(n_fft).to(x),
-                win_length=n_fft,
-                normalized=True,
-                center=True,
-                return_complex=True,
-                pad_mode='reflect')
+        z = th.stft(x,
+                    n_fft * (1 + pad),
+                    hop_length or n_fft // 4,
+                    window=th.hann_window(n_fft).to(x),
+                    win_length=n_fft,
+                    normalized=True,
+                    center=True,
+                    return_complex=True,
+                    pad_mode='reflect')
+        if original_device.type == "cuda":
+            try:
+                z = z.to(original_device)
+            except Exception:
+                pass
     _, freqs, frame = z.shape
     return z.view(*other, freqs, frame)
 
@@ -35,19 +47,30 @@ def ispectro(z, hop_length=None, length=None, pad=0):
     n_fft = 2 * freqs - 2
     z = z.view(-1, freqs, frames)
     win_length = n_fft // (1 + pad)
-    
-    device_type = z.device.type
-    is_other_gpu = not device_type in ["cuda", "cpu"]
-    
-    if is_other_gpu:
+    original_device = z.device
+    try:
+        x = th.istft(z,
+                     n_fft,
+                     hop_length,
+                     window=th.hann_window(win_length).to(z.real),
+                     win_length=win_length,
+                     normalized=True,
+                     length=length,
+                     center=True)
+    except Exception:
         z = z.cpu()
-    x = th.istft(z,
-                 n_fft,
-                 hop_length,
-                 window=th.hann_window(win_length).to(z.real),
-                 win_length=win_length,
-                 normalized=True,
-                 length=length,
-                 center=True)
+        x = th.istft(z,
+                     n_fft,
+                     hop_length,
+                     window=th.hann_window(win_length).to(z.real),
+                     win_length=win_length,
+                     normalized=True,
+                     length=length,
+                     center=True)
+        if original_device.type in ["cuda", "mps"]:
+            try:
+                x = x.to(original_device)
+            except Exception:
+                pass
     _, length = x.shape
     return x.view(*other, length)

--- a/demucs/states.py
+++ b/demucs/states.py
@@ -43,7 +43,10 @@ def load_model(path_or_package, strict=False):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             path = path_or_package
-            package = torch.load(path, 'cpu')
+            try:
+                package = torch.load(path, map_location='cpu', weights_only=False)
+            except TypeError:
+                package = torch.load(path, 'cpu')
     else:
         raise ValueError(f"Invalid type for {path_or_package}.")
 

--- a/gui_data/constants.py
+++ b/gui_data/constants.py
@@ -507,6 +507,12 @@ MP3 = 'MP3'
 MP3_BIT_RATES = ('96k', '128k', '160k', '224k', '256k', '320k')
 WAV_TYPE = ('PCM_U8', 'PCM_16', 'PCM_24', 'PCM_32', '32-bit Float', '64-bit Float')
 GPU_DEVICE_NUM_OPTS = (DEFAULT, '0', '1', '2', '3', '4', '5', '6', '7', '8')
+BACKEND_AUTO = 'Auto'
+BACKEND_CPU = 'CPU'
+BACKEND_CUDA = 'CUDA'
+BACKEND_MPS = 'Apple GPU (MPS)'
+BACKEND_COREML = 'CoreML'
+BACKEND_MODE_OPTIONS = (BACKEND_AUTO, BACKEND_CPU, BACKEND_CUDA, BACKEND_MPS, BACKEND_COREML)
 
 SELECT_SAVED_SET = 'Choose Option'
 SAVE_SETTINGS = 'Save Current Settings'
@@ -637,6 +643,7 @@ DEFAULT_DATA = {
         'pitch_rate': 2.0,
         'is_time_correction': True,
         'is_gpu_conversion': False,
+        'backend_mode': BACKEND_AUTO,
         'is_primary_stem_only': False,
         'is_secondary_stem_only': False,
         'is_testing_audio': False,#
@@ -766,6 +773,7 @@ SETTING_CHECK = ('vr_model',
                'device_set',
                'user_code',
                'is_gpu_conversion',
+               'backend_mode',
                'is_normalization',
                'is_use_opencl',
                'is_wav_ensemble',
@@ -1004,15 +1012,15 @@ ENSEMBLE_LISTBOX_HELP = (
     'Displays all available models for the chosen main stem pair.'
 )
 
-if OPERATING_SYSTEM == 'darwin':
+if OPERATING_SYSTEM == 'Darwin':
    IS_GPU_CONVERSION_HELP = (
       '• Use GPU for Processing (if available):\n'
-      '  - If checked, the application will attempt to use your GPU for faster processing.\n'
-      '  - If a GPU is not detected, it will default to CPU processing.\n'
-      '  - GPU processing for MacOS only works with VR Arch models.\n\n'
+      '  - If checked, the application will attempt to use Apple Silicon GPU acceleration through MPS.\n'
+      '  - Some model paths may fall back to CPU if an operation is unsupported.\n'
+      '  - CoreML can be selected as an experimental ONNX backend from general settings.\n\n'
       '• Please Note:\n'
       '  - CPU processing is significantly slower than GPU processing.\n'
-      '  - Only Macs with M1 chips can be used for GPU processing.'
+      '  - Apple Silicon Macs are required for MPS GPU processing.'
    )
 else:
    IS_GPU_CONVERSION_HELP = (
@@ -1027,7 +1035,8 @@ else:
 IS_TIME_CORRECTION_HELP = ('When checked, the output will retain the original BPM of the input.')
 SAVE_STEM_ONLY_HELP = 'Allows the user to save only the selected stem.'
 IS_NORMALIZATION_HELP = 'Normalizes output to prevent clipping.'
-IS_CUDA_SELECT_HELP = "If you have more than one GPU, you can pick which one to use for processing."
+IS_CUDA_SELECT_HELP = "If you have more than one Nvidia GPU, you can pick which one to use for processing."
+BACKEND_MODE_HELP = "Select the inference backend. Auto prefers CUDA, then Apple GPU (MPS), then CPU."
 CROP_SIZE_HELP = '**Only compatible with select models only!**\n\n Setting should match training crop-size value. Leave as is if unsure.'
 IS_TTA_HELP = ('This option performs Test-Time-Augmentation to improve the separation quality.\n\n'
                'Note: Having this selected will increase the time it takes to complete a conversion')
@@ -1514,6 +1523,7 @@ VR_51_MODEL_TEXT = 'VR 5.1 Model'
 VR_ARCH_TEXT = 'VR Arch'
 WAV_TYPE_TEXT = 'Wav Type'
 CUDA_NUM_TEXT = 'GPU Device'
+BACKEND_MODE_TEXT = 'Inference Backend'
 WINDOW_SIZE_TEXT = 'Window Size'
 YES_TEXT = 'Yes'
 VERIFY_INPUTS_TEXT = 'Verify Inputs'

--- a/inference_backend.py
+++ b/inference_backend.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import gc
+import os
+import platform
+
+os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+from gui_data.constants import (
+    BACKEND_AUTO,
+    BACKEND_CPU,
+    BACKEND_CUDA,
+    BACKEND_MPS,
+    BACKEND_COREML,
+    BACKEND_MODE_OPTIONS,
+    CUDA_DEVICE,
+    DEFAULT,
+    DEMUCS_ARCH_TYPE,
+    DEMUCS_V3,
+    DEMUCS_V4,
+)
+
+TORCH_CPU = "cpu"
+TORCH_CUDA = "cuda"
+TORCH_MPS = "mps"
+
+ONNX_CPU_PROVIDER = "CPUExecutionProvider"
+ONNX_CUDA_PROVIDER = "CUDAExecutionProvider"
+ONNX_COREML_PROVIDER = "CoreMLExecutionProvider"
+
+OPERATING_SYSTEM = platform.system()
+is_macos = OPERATING_SYSTEM == "Darwin"
+cuda_available = torch.cuda.is_available()
+mps_available = bool(
+    is_macos
+    and hasattr(torch.backends, "mps")
+    and torch.backends.mps.is_available()
+)
+_mps_stft_supported = None
+
+
+@dataclass(frozen=True)
+class BackendPlan:
+    mode: str
+    torch_device: Any
+    torch_backend: str
+    onnx_providers: list
+    prefer_onnx2torch: bool
+    fallback_to_cpu: bool
+    supports_stft: bool
+    supports_complex: bool
+    label: str
+
+    @property
+    def is_mps(self) -> bool:
+        return self.torch_backend == TORCH_MPS
+
+    @property
+    def is_cuda(self) -> bool:
+        return self.torch_backend == TORCH_CUDA
+
+    @property
+    def is_cpu(self) -> bool:
+        return self.torch_backend == TORCH_CPU
+
+
+def _normalize_backend_mode(mode: str | None) -> str:
+    if mode in BACKEND_MODE_OPTIONS:
+        return mode
+    return BACKEND_AUTO
+
+
+def _cuda_device(device_set: str | None):
+    if device_set and device_set != DEFAULT:
+        return f"{CUDA_DEVICE}:{device_set}"
+    return CUDA_DEVICE
+
+
+def _coreml_options(cache_dir: str | None = None) -> tuple[str, dict]:
+    options = {
+        "ModelFormat": "MLProgram",
+        "MLComputeUnits": "CPUAndGPU",
+        "RequireStaticInputShapes": "1",
+        "EnableOnSubgraphs": "1",
+    }
+    if cache_dir:
+        options["ModelCacheDirectory"] = cache_dir
+    return ONNX_COREML_PROVIDER, options
+
+
+def plan_backend(
+    backend_mode: str | None,
+    gpu_enabled: bool,
+    device_set: str | None = DEFAULT,
+    process_method: str | None = None,
+    demucs_version: str | None = None,
+    coreml_cache_dir: str | None = None,
+) -> BackendPlan:
+    mode = _normalize_backend_mode(backend_mode)
+
+    if not gpu_enabled:
+        mode = BACKEND_CPU
+
+    if process_method == DEMUCS_ARCH_TYPE and demucs_version not in (DEMUCS_V3, DEMUCS_V4):
+        if mode in (BACKEND_AUTO, BACKEND_MPS, BACKEND_COREML):
+            mode = BACKEND_CPU
+
+    onnx_providers = [ONNX_CPU_PROVIDER]
+    torch_device: Any = torch.device(TORCH_CPU)
+    torch_backend = TORCH_CPU
+    prefer_onnx2torch = False
+    fallback_to_cpu = False
+    label = BACKEND_CPU
+
+    if mode == BACKEND_CUDA or (mode == BACKEND_AUTO and cuda_available):
+        if cuda_available:
+            torch_device = _cuda_device(device_set)
+            torch_backend = TORCH_CUDA
+            onnx_providers = [ONNX_CUDA_PROVIDER, ONNX_CPU_PROVIDER]
+            label = BACKEND_CUDA
+        else:
+            fallback_to_cpu = True
+    elif mode == BACKEND_MPS or (mode == BACKEND_AUTO and mps_available):
+        if mps_available:
+            torch_device = torch.device(TORCH_MPS)
+            torch_backend = TORCH_MPS
+            prefer_onnx2torch = True
+            label = BACKEND_MPS
+        else:
+            fallback_to_cpu = True
+    elif mode == BACKEND_COREML or (mode == BACKEND_AUTO and is_macos):
+        if is_macos:
+            onnx_providers = [_coreml_options(coreml_cache_dir), ONNX_CPU_PROVIDER]
+            label = BACKEND_COREML if mode == BACKEND_COREML else f"{BACKEND_CPU} / {BACKEND_COREML} ONNX"
+        else:
+            fallback_to_cpu = True
+
+    if fallback_to_cpu:
+        torch_device = torch.device(TORCH_CPU)
+        torch_backend = TORCH_CPU
+        onnx_providers = [ONNX_CPU_PROVIDER]
+        prefer_onnx2torch = False
+        label = f"{BACKEND_CPU} (fallback)"
+
+    supports_stft = torch_backend != TORCH_MPS or is_mps_stft_supported()
+    supports_complex = torch_backend != TORCH_MPS or supports_stft
+
+    return BackendPlan(
+        mode=mode,
+        torch_device=torch_device,
+        torch_backend=torch_backend,
+        onnx_providers=onnx_providers,
+        prefer_onnx2torch=prefer_onnx2torch,
+        fallback_to_cpu=fallback_to_cpu,
+        supports_stft=supports_stft,
+        supports_complex=supports_complex,
+        label=label,
+    )
+
+
+def clear_backend_cache(plan: BackendPlan | None = None):
+    gc.collect()
+    if plan and plan.is_mps and hasattr(torch, "mps") and hasattr(torch.mps, "empty_cache"):
+        torch.mps.empty_cache()
+    elif plan and plan.is_cuda:
+        torch.cuda.empty_cache()
+    elif plan is None:
+        if mps_available and hasattr(torch, "mps") and hasattr(torch.mps, "empty_cache"):
+            torch.mps.empty_cache()
+        if cuda_available:
+            torch.cuda.empty_cache()
+
+
+def is_mps_stft_supported() -> bool:
+    global _mps_stft_supported
+    if _mps_stft_supported is not None:
+        return _mps_stft_supported
+
+    if not mps_available:
+        _mps_stft_supported = False
+        return False
+    try:
+        device = torch.device(TORCH_MPS)
+        wave = torch.zeros(1, 2048, device=device)
+        window = torch.hann_window(512, device=device)
+        spec = torch.stft(wave, 512, 128, window=window, return_complex=True)
+        torch.istft(spec, 512, 128, window=window, length=2048)
+        _mps_stft_supported = True
+    except Exception:
+        _mps_stft_supported = False
+    return _mps_stft_supported
+
+
+def enable_mps_fallback_env():
+    os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")

--- a/lib_v5/tfc_tdf_v3.py
+++ b/lib_v5/tfc_tdf_v3.py
@@ -11,29 +11,28 @@ class STFT:
         self.device = device
 
     def __call__(self, x):
-        
-        x_is_mps = not x.device.type in ["cuda", "cpu"]
-        if x_is_mps:
-            x = x.cpu()
+        original_device = x.device
 
         window = self.window.to(x.device)
         batch_dims = x.shape[:-2]
         c, t = x.shape[-2:]
         x = x.reshape([-1, t])
-        x = torch.stft(x, n_fft=self.n_fft, hop_length=self.hop_length, window=window, center=True,return_complex=False)
+        try:
+            x = torch.stft(x, n_fft=self.n_fft, hop_length=self.hop_length, window=window, center=True, return_complex=False)
+        except Exception:
+            x = x.cpu()
+            window = self.window.to(x.device)
+            x = torch.stft(x, n_fft=self.n_fft, hop_length=self.hop_length, window=window, center=True, return_complex=False)
         x = x.permute([0, 3, 1, 2])
         x = x.reshape([*batch_dims, c, 2, -1, x.shape[-1]]).reshape([*batch_dims, c * 2, -1, x.shape[-1]])
 
-        if x_is_mps:
+        if x.device != original_device:
             x = x.to(self.device)
 
         return x[..., :self.dim_f, :]
 
     def inverse(self, x):
-        
-        x_is_mps = not x.device.type in ["cuda", "cpu"]
-        if x_is_mps:
-            x = x.cpu()
+        original_device = x.device
 
         window = self.window.to(x.device)
         batch_dims = x.shape[:-3]
@@ -43,11 +42,17 @@ class STFT:
         x = torch.cat([x, f_pad], -2)
         x = x.reshape([*batch_dims, c // 2, 2, n, t]).reshape([-1, 2, n, t])
         x = x.permute([0, 2, 3, 1])
-        x = x[..., 0] + x[..., 1] * 1.j
-        x = torch.istft(x, n_fft=self.n_fft, hop_length=self.hop_length, window=window, center=True)
+        try:
+            x_complex = x[..., 0] + x[..., 1] * 1.j
+            x = torch.istft(x_complex, n_fft=self.n_fft, hop_length=self.hop_length, window=window, center=True)
+        except Exception:
+            x = x.cpu()
+            window = self.window.to(x.device)
+            x_complex = x[..., 0] + x[..., 1] * 1.j
+            x = torch.istft(x_complex, n_fft=self.n_fft, hop_length=self.hop_length, window=window, center=True)
         x = x.reshape([*batch_dims, 2, -1])
 
-        if x_is_mps:
+        if x.device != original_device:
             x = x.to(self.device)
 
         return x
@@ -249,5 +254,3 @@ class TFC_TDF_net(nn.Module):
         x = self.stft.inverse(x)
 
         return x
-
-

--- a/packaging/macos/UVR-macos-arm64.spec
+++ b/packaging/macos/UVR-macos-arm64.spec
@@ -1,0 +1,153 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller spec for a local macOS Apple Silicon UVR build.
+
+This bundle intentionally includes model metadata and configuration files but
+excludes downloaded model weights. Users can download or place model weights in
+the app's model directories after launch.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+
+from PyInstaller.utils.hooks import collect_data_files, collect_dynamic_libs, collect_submodules
+
+
+ROOT = Path(SPECPATH).resolve().parents[1]
+APP_NAME = "Ultimate Vocal Remover"
+ICON = ROOT / "gui_data" / "img" / "UVR.icns"
+
+
+def add_tree(source: str, dest: str, excludes: tuple[str, ...] = ()) -> list[tuple[str, str]]:
+    source_path = ROOT / source
+    if not source_path.exists():
+        return []
+
+    datas: list[tuple[str, str]] = []
+    for path in source_path.rglob("*"):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(source_path)
+        rel_posix = rel.as_posix()
+        if any(path.match(pattern) or rel_posix.endswith(pattern) for pattern in excludes):
+            continue
+        datas.append((str(path), str(Path(dest) / rel.parent)))
+    return datas
+
+
+def add_if_exists(source: Path, dest: str) -> list[tuple[str, str]]:
+    return [(str(source), dest)] if source.exists() else []
+
+
+datas: list[tuple[str, str]] = []
+datas += add_tree("gui_data", "gui_data", excludes=("__pycache__",))
+datas += add_tree("lib_v5", "lib_v5", excludes=("__pycache__",))
+datas += add_tree("demucs", "demucs", excludes=("__pycache__",))
+datas += add_tree("models/VR_Models/model_data", "models/VR_Models/model_data")
+datas += add_tree("models/MDX_Net_Models/model_data", "models/MDX_Net_Models/model_data")
+datas += add_tree("models/Demucs_Models/model_data", "models/Demucs_Models/model_data")
+datas += add_if_exists(ROOT / "models" / "Demucs_Models" / "v3_v4_repo" / "demucs_models.txt", "models/Demucs_Models/v3_v4_repo")
+
+ffmpeg_path = shutil.which("ffmpeg")
+if ffmpeg_path:
+    datas.append((ffmpeg_path, "."))
+
+rubberband_path = shutil.which("rubberband")
+if rubberband_path:
+    datas.append((rubberband_path, "."))
+
+datas += collect_data_files("librosa")
+datas += collect_data_files("pydub")
+datas += collect_data_files("sklearn")
+datas += collect_data_files("onnxruntime")
+datas += collect_data_files("soundfile")
+datas += collect_dynamic_libs("onnxruntime")
+datas += collect_dynamic_libs("soundfile")
+
+hiddenimports = []
+hiddenimports += collect_submodules("demucs")
+hiddenimports += collect_submodules("gui_data")
+hiddenimports += collect_submodules("lib_v5")
+hiddenimports += collect_submodules("onnx2pytorch")
+hiddenimports += collect_submodules("onnxruntime")
+hiddenimports += collect_submodules("sklearn")
+hiddenimports += collect_submodules("yaml")
+hiddenimports += [
+    "PIL._tkinter_finder",
+    "audioread",
+    "librosa",
+    "ml_collections",
+    "numpy",
+    "pydub",
+    "scipy",
+    "soundfile",
+    "torch",
+    "torch.testing._comparison",
+    "torch.testing._creation",
+    "torchaudio",
+]
+
+block_cipher = None
+
+a = Analysis(
+    [str(ROOT / "UVR.py")],
+    pathex=[str(ROOT)],
+    binaries=[],
+    datas=datas,
+    hiddenimports=sorted(set(hiddenimports)),
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[
+        "matplotlib.tests",
+        "numpy.tests",
+        "scipy.tests",
+    ],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name=APP_NAME,
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=False,
+    target_arch="arm64",
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name=APP_NAME,
+)
+
+app = BUNDLE(
+    coll,
+    name=f"{APP_NAME}.app",
+    icon=str(ICON),
+    bundle_identifier="com.uvr5.local",
+    info_plist={
+        "CFBundleName": APP_NAME,
+        "CFBundleDisplayName": APP_NAME,
+        "CFBundleShortVersionString": "5.6-mps-local",
+        "CFBundleVersion": "5.6.0",
+        "NSHighResolutionCapable": True,
+        "LSMinimumSystemVersion": "11.0",
+    },
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ diffq
 playsound
 onnx
 onnxruntime
-onnxruntime-gpu
+onnxruntime-gpu; sys_platform != 'darwin'
 onnx2pytorch
 SoundFile==0.11.0; sys_platform != 'darwin'
 PySoundFile==0.9.0.post1; sys_platform == 'darwin'

--- a/separate.py
+++ b/separate.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+import os
+os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
 from typing import TYPE_CHECKING
 from demucs.apply import apply_model, demucs_segments
 from demucs.hdemucs import HDemucs
@@ -14,6 +17,15 @@ from lib_v5.vr_network.model_param_init import ModelParameters
 from pathlib import Path
 from gui_data.constants import *
 from gui_data.error_handling import *
+from inference_backend import (
+    BACKEND_AUTO,
+    BACKEND_COREML,
+    clear_backend_cache,
+    cuda_available,
+    enable_mps_fallback_env,
+    mps_available,
+    plan_backend,
+)
 from scipy import signal
 import audioread
 import gzip
@@ -21,10 +33,11 @@ import librosa
 import math
 import numpy as np
 import onnxruntime as ort
-import os
 import torch
+import time
 import warnings
 import pydub
+import shutil
 import soundfile as sf
 import lib_v5.mdxnet as MdxnetSet
 import math
@@ -36,11 +49,7 @@ import gc
 if TYPE_CHECKING:
     from UVR import ModelData
 
-# if not is_macos:
-#     import torch_directml
-
-mps_available = torch.backends.mps.is_available() if is_macos else False
-cuda_available = torch.cuda.is_available()
+enable_mps_fallback_env()
 
 # def get_gpu_info():
 #     directml_device, directml_available = DIRECTML_DEVICE, False
@@ -56,14 +65,70 @@ cuda_available = torch.cuda.is_available()
 # DIRECTML_DEVICE, directml_available = get_gpu_info()
 
 def clear_gpu_cache():
-    gc.collect()
-    if is_macos:
-        torch.mps.empty_cache()
-    else:
-        torch.cuda.empty_cache()
+    clear_backend_cache()
 
 warnings.filterwarnings("ignore")
 cpu = torch.device('cpu')
+
+
+class TorchModelRunner:
+    def __init__(self, model):
+        self.model = model
+
+    def __call__(self, tensor):
+        return self.model(tensor)
+
+
+class OnnxRuntimeRunner:
+    def __init__(self, model_path, providers):
+        available_providers = set(ort.get_available_providers())
+        selected_providers = []
+        for provider in providers:
+            provider_name = provider[0] if isinstance(provider, tuple) else provider
+            if provider_name in available_providers:
+                selected_providers.append(provider)
+        if not selected_providers:
+            selected_providers = ['CPUExecutionProvider']
+
+        try:
+            self.session = ort.InferenceSession(model_path, providers=selected_providers)
+        except Exception:
+            self.session = ort.InferenceSession(model_path, providers=['CPUExecutionProvider'])
+        self.backend_label = f'ONNX Runtime ({", ".join(self.session.get_providers())})'
+
+    def __call__(self, tensor):
+        output = self.session.run(None, {'input': tensor.detach().cpu().numpy()})[0]
+        return torch.from_numpy(output).to(tensor.device)
+
+
+class Onnx2TorchRunner:
+    def __init__(self, model_path, device):
+        self.model = ConvertModel(load(model_path))
+        self.model.to(device).eval()
+
+    def __call__(self, tensor):
+        return self.model(tensor)
+
+
+class MdxOnnxRunner:
+    def __init__(self, model_path, backend_plan, use_onnxruntime):
+        if use_onnxruntime:
+            self.runner = OnnxRuntimeRunner(model_path, backend_plan.onnx_providers)
+            self.backend_label = self.runner.backend_label
+        else:
+            self.runner = Onnx2TorchRunner(model_path, backend_plan.torch_device)
+            self.backend_label = 'ONNX converted to PyTorch'
+
+    def __call__(self, tensor):
+        return self.runner(tensor)
+
+
+class TimedSection:
+    def __init__(self):
+        self.started = time.perf_counter()
+
+    def elapsed(self):
+        return time.perf_counter() - self.started
 
 class SeperateAttributes:
     def __init__(self, model_data: ModelData, 
@@ -120,6 +185,7 @@ class SeperateAttributes:
         self.mp3_bit_set = model_data.mp3_bit_set
         self.save_format = model_data.save_format
         self.is_gpu_conversion = model_data.is_gpu_conversion
+        self.backend_mode = getattr(model_data, 'backend_mode', BACKEND_AUTO)
         self.is_normalization = model_data.is_normalization
         self.is_primary_stem_only = model_data.is_primary_stem_only if not self.is_secondary_model else model_data.is_primary_model_primary_stem_only
         self.is_secondary_stem_only = model_data.is_secondary_stem_only if not self.is_secondary_model else model_data.is_primary_model_secondary_stem_only      
@@ -169,6 +235,19 @@ class SeperateAttributes:
         self.is_opencl = False
         self.device_set = model_data.device_set
         self.is_use_opencl = model_data.is_use_opencl
+        self.backend_plan = plan_backend(
+            self.backend_mode,
+            self.is_gpu_conversion >= 0,
+            self.device_set,
+            process_method=model_data.process_method,
+            demucs_version=getattr(model_data, 'demucs_version', None),
+            coreml_cache_dir=os.path.join(os.getcwd(), 'coreml_cache'),
+        )
+        self.device = self.backend_plan.torch_device
+        self.run_type = self.backend_plan.onnx_providers
+        self.is_other_gpu = self.backend_plan.is_mps
+        self.model_load_timer = None
+        self.model_runner_label = None
         
         if self.is_inst_only_voc_splitter or self.is_sec_bv_rebalance:
             self.is_primary_stem_only = False
@@ -176,21 +255,6 @@ class SeperateAttributes:
         
         if main_model_primary and self.is_multi_stem_ensemble:
             self.primary_stem, self.secondary_stem = main_model_primary, secondary_stem(main_model_primary)
-
-        if self.is_gpu_conversion >= 0:
-            if mps_available:
-                self.device, self.is_other_gpu = 'mps', True
-            else:
-                device_prefix = None
-                if self.device_set != DEFAULT:
-                    device_prefix = CUDA_DEVICE#DIRECTML_DEVICE if self.is_use_opencl and directml_available else CUDA_DEVICE
-
-                # if directml_available and self.is_use_opencl:
-                #     self.device = torch_directml.device() if not device_prefix else f'{device_prefix}:{self.device_set}'
-                #     self.is_other_gpu = True
-                if cuda_available:# and not self.is_use_opencl:
-                    self.device = CUDA_DEVICE if not device_prefix else f'{device_prefix}:{self.device_set}'
-                    self.run_type = ['CUDAExecutionProvider']
 
         if model_data.process_method == MDX_ARCH_TYPE:
             self.is_mdx_ckpt = model_data.is_mdx_ckpt
@@ -229,7 +293,7 @@ class SeperateAttributes:
             self.is_demucs_combine_stems = model_data.is_demucs_combine_stems
             self.demucs_stem_count = model_data.demucs_stem_count
             self.pre_proc_model = model_data.pre_proc_model
-            self.device = cpu if self.is_other_gpu and not self.demucs_version in [DEMUCS_V3, DEMUCS_V4] else self.device
+            self.device = cpu if self.backend_plan.is_mps and not self.demucs_version in [DEMUCS_V3, DEMUCS_V4] else self.device
 
             self.primary_stem = model_data.ensemble_primary_stem if process_data['is_ensemble_master'] else model_data.primary_stem
             self.secondary_stem = model_data.ensemble_secondary_stem if process_data['is_ensemble_master'] else model_data.secondary_stem
@@ -288,6 +352,7 @@ class SeperateAttributes:
             self.is_secondary_stem_only = False
             
     def start_inference_console_write(self):
+        self.model_load_timer = TimedSection()
         if self.is_secondary_model and not self.is_pre_proc_model and not self.is_vocal_split_model:
             self.write_to_console(INFERENCE_STEP_2_SEC(self.process_method, self.model_basename))
         
@@ -300,6 +365,12 @@ class SeperateAttributes:
     def running_inference_console_write(self, is_no_write=False):
         self.write_to_console(DONE, base_text='') if not is_no_write else None
         self.set_progress_bar(0.05) if not is_no_write else None
+        if not is_no_write and self.model_load_timer:
+            runner_info = f' | Runner: {self.model_runner_label}' if self.model_runner_label else ''
+            self.write_to_console(
+                f'Backend: {self.backend_plan.label}{runner_info} | Model load: {self.model_load_timer.elapsed():.2f}s\n'
+            )
+            self.model_load_timer = None
         
         if self.is_secondary_model and not self.is_pre_proc_model and not self.is_vocal_split_model:
             self.write_to_console(INFERENCE_STEP_1_SEC)
@@ -484,14 +555,14 @@ class SeperateMDX(SeperateAttributes):
                 model_params = torch.load(self.model_path, map_location=lambda storage, loc: storage)['hyper_parameters']
                 self.dim_c, self.hop = model_params['dim_c'], model_params['hop_length']
                 separator = MdxnetSet.ConvTDFNet(**model_params)
-                self.model_run = separator.load_from_checkpoint(self.model_path).to(self.device).eval()
+                self.model_run = TorchModelRunner(separator.load_from_checkpoint(self.model_path).to(self.device).eval())
             else:
-                if self.mdx_segment_size == self.dim_t and not self.is_other_gpu:
-                    ort_ = ort.InferenceSession(self.model_path, providers=self.run_type)
-                    self.model_run = lambda spek:ort_.run(None, {'input': spek.cpu().numpy()})[0]
-                else:
-                    self.model_run = ConvertModel(load(self.model_path))
-                    self.model_run.to(self.device).eval()
+                use_onnxruntime = (
+                    self.backend_mode == BACKEND_COREML or
+                    (self.mdx_segment_size == self.dim_t and not self.backend_plan.prefer_onnx2torch)
+                )
+                self.model_run = MdxOnnxRunner(self.model_path, self.backend_plan, use_onnxruntime)
+                self.model_runner_label = self.model_run.backend_label
 
             self.running_inference_console_write()
             mix = prepare_mix(self.audio_file)
@@ -561,8 +632,8 @@ class SeperateMDX(SeperateAttributes):
         mixture = np.concatenate((np.zeros((2, self.trim), dtype='float32'), mix, np.zeros((2, pad), dtype='float32')), 1)
 
         step = self.chunk_size - self.n_fft if overlap == DEFAULT else int((1 - overlap) * chunk_size)
-        result = np.zeros((1, 2, mixture.shape[-1]), dtype=np.float32)
-        divider = np.zeros((1, 2, mixture.shape[-1]), dtype=np.float32)
+        result = torch.zeros((1, 2, mixture.shape[-1]), dtype=torch.float32, device=self.device)
+        divider = torch.zeros((1, 2, mixture.shape[-1]), dtype=torch.float32, device=self.device)
         total = 0
         total_chunks = (mixture.shape[-1] + step - 1) // step
 
@@ -576,8 +647,8 @@ class SeperateMDX(SeperateAttributes):
             if overlap == 0:
                 window = None
             else:
-                window = np.hanning(chunk_size_actual)
-                window = np.tile(window[None, None, :], (1, 2, 1))
+                window = torch.from_numpy(np.hanning(chunk_size_actual).astype(np.float32)).to(self.device)
+                window = window[None, None, :].repeat(1, 2, 1)
 
             mix_part_ = mixture[:, start:end]
             if end != i + chunk_size:
@@ -594,14 +665,14 @@ class SeperateMDX(SeperateAttributes):
                     tar_waves = self.run_model(mix_wave, is_match_mix=is_match_mix)
                     
                     if window is not None:
-                        tar_waves[..., :chunk_size_actual] *= window 
+                        tar_waves[..., :chunk_size_actual] *= window
                         divider[..., start:end] += window
                     else:
                         divider[..., start:end] += 1
 
                     result[..., start:end] += tar_waves[..., :end-start]
-            
-        tar_waves = result / divider
+
+        tar_waves = (result / divider).cpu().numpy()
         tar_waves_.append(tar_waves)
 
         tar_waves_ = np.vstack(tar_waves_)[:, :, self.trim:-self.trim]
@@ -630,11 +701,11 @@ class SeperateMDX(SeperateAttributes):
         spek[:, :, :3, :] *= 0 
 
         if is_match_mix:
-            spec_pred = spek.cpu().numpy()
+            spec_pred = spek
         else:
             spec_pred = -self.model_run(-spek)*0.5+self.model_run(spek)*0.5 if self.is_denoise else self.model_run(spek)
 
-        return self.stft.inverse(torch.tensor(spec_pred).to(self.device)).cpu().detach().numpy()
+        return self.stft.inverse(spec_pred.to(self.device)).detach()
 
 class SeperateMDXC(SeperateAttributes):        
 
@@ -983,29 +1054,41 @@ class SeperateDemucs(SeperateAttributes):
         mix = (mix - ref.mean()) / ref.std()
         mix_infer = mix 
         
-        with torch.no_grad():
-            if self.demucs_version == DEMUCS_V1:
-                sources = apply_model_v1(self.demucs, 
-                                            mix_infer.to(self.device), 
-                                            self.shifts, 
-                                            self.is_split_mode,
-                                            set_progress_bar=self.set_progress_bar)
-            elif self.demucs_version == DEMUCS_V2:
-                sources = apply_model_v2(self.demucs, 
-                                            mix_infer.to(self.device), 
-                                            self.shifts,
-                                            self.is_split_mode,
-                                            self.overlap,
-                                            set_progress_bar=self.set_progress_bar)
+        def run_demucs_on(device):
+            self.demucs.to(device)
+            with torch.no_grad():
+                if self.demucs_version == DEMUCS_V1:
+                    return apply_model_v1(self.demucs,
+                                          mix_infer.to(device),
+                                          self.shifts,
+                                          self.is_split_mode,
+                                          set_progress_bar=self.set_progress_bar)
+                elif self.demucs_version == DEMUCS_V2:
+                    return apply_model_v2(self.demucs,
+                                          mix_infer.to(device),
+                                          self.shifts,
+                                          self.is_split_mode,
+                                          self.overlap,
+                                          set_progress_bar=self.set_progress_bar)
+                else:
+                    return apply_model(self.demucs,
+                                       mix_infer[None],
+                                       self.shifts,
+                                       self.is_split_mode,
+                                       self.overlap,
+                                       static_shifts=1 if self.shifts == 0 else self.shifts,
+                                       set_progress_bar=self.set_progress_bar,
+                                       device=device)[0]
+
+        try:
+            sources = run_demucs_on(self.device)
+        except Exception as e:
+            if self.backend_plan.is_mps and self.demucs_version in [DEMUCS_V3, DEMUCS_V4]:
+                self.write_to_console(f'\nApple GPU backend failed for Demucs; falling back to CPU. ({e})\n', base_text='')
+                self.device = cpu
+                sources = run_demucs_on(cpu)
             else:
-                sources = apply_model(self.demucs, 
-                                        mix_infer[None], 
-                                        self.shifts,
-                                        self.is_split_mode,
-                                        self.overlap,
-                                        static_shifts=1 if self.shifts == 0 else self.shifts,
-                                        set_progress_bar=self.set_progress_bar,
-                                        device=self.device)[0]
+                raise
         
         sources = (sources * ref.std() + ref.mean()).cpu().numpy()
         sources[[0,1]] = sources[[1,0]]
@@ -1313,7 +1396,7 @@ def save_format(audio_path, save_format, mp3_bit_set):
         
         if OPERATING_SYSTEM == 'Darwin':
             FFMPEG_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'ffmpeg')
-            pydub.AudioSegment.converter = FFMPEG_PATH
+            pydub.AudioSegment.converter = FFMPEG_PATH if os.path.isfile(FFMPEG_PATH) else shutil.which('ffmpeg')
         
         musfile = pydub.AudioSegment.from_wav(audio_path)
         

--- a/tools/build_macos_app.sh
+++ b/tools/build_macos_app.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+APP_NAME="Ultimate Vocal Remover"
+APP_PATH="$ROOT_DIR/dist/${APP_NAME}.app"
+SPEC_PATH="$ROOT_DIR/packaging/macos/UVR-macos-arm64.spec"
+PYTHON_BIN="$ROOT_DIR/.venv-build-macos/bin/python"
+SIGNING_DIR=""
+
+cleanup() {
+  if [[ -n "$SIGNING_DIR" && -d "$SIGNING_DIR" ]]; then
+    rm -rf "$SIGNING_DIR"
+  fi
+}
+trap cleanup EXIT
+
+if [[ "$(uname -m)" != "arm64" ]]; then
+  echo "error: macOS arm64 build requires an arm64 shell; got $(uname -m)" >&2
+  exit 1
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "error: uv is required to create the build environment" >&2
+  exit 1
+fi
+
+uv python install 3.10
+rm -rf "$ROOT_DIR/.venv-build-macos"
+uv venv "$ROOT_DIR/.venv-build-macos" --python 3.10
+"$PYTHON_BIN" -m ensurepip --upgrade
+"$PYTHON_BIN" -m pip install --upgrade pip wheel setuptools
+"$PYTHON_BIN" -m pip install playsound==1.2.2
+SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True "$PYTHON_BIN" -m pip install -r requirements.txt
+"$PYTHON_BIN" -m pip uninstall -y PySoundFile || true
+"$PYTHON_BIN" -m pip install onnx2pytorch pyinstaller
+"$PYTHON_BIN" -m pip install --force-reinstall --no-deps soundfile==0.13.1
+
+"$PYTHON_BIN" - <<'PY'
+import platform
+import sys
+import torch
+import PyInstaller
+
+if platform.machine() != "arm64":
+    raise SystemExit(f"error: expected arm64 Python, got {platform.machine()}")
+if sys.version_info[:2] != (3, 10):
+    raise SystemExit(f"error: expected Python 3.10, got {sys.version}")
+if not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()):
+    raise SystemExit("error: torch MPS is not available in the build environment")
+print("prebuild ok:", sys.executable, platform.platform(), "PyInstaller", PyInstaller.__version__)
+PY
+
+if ! command -v ffmpeg >/dev/null 2>&1; then
+  echo "warning: ffmpeg was not found on PATH; MP3/FLAC export may fail in the packaged app" >&2
+fi
+
+if ! command -v rubberband >/dev/null 2>&1; then
+  echo "warning: rubberband was not found on PATH; time-stretch/pitch-shift tools are not bundled" >&2
+fi
+
+rm -rf "$ROOT_DIR/build" "$ROOT_DIR/dist"
+"$PYTHON_BIN" -m PyInstaller --noconfirm --clean "$SPEC_PATH"
+
+if [[ ! -d "$APP_PATH" ]]; then
+  echo "error: expected app bundle was not created at $APP_PATH" >&2
+  exit 1
+fi
+
+find "$ROOT_DIR/dist" -name '._*' -exec rm -rf {} +
+SIGNING_DIR="$(mktemp -d "${TMPDIR:-/tmp}/uvr-macos-signing.XXXXXX")"
+SIGNED_APP_PATH="$SIGNING_DIR/${APP_NAME}.app"
+ditto --norsrc --noextattr "$APP_PATH" "$SIGNED_APP_PATH"
+find "$SIGNED_APP_PATH" -name '._*' -exec rm -rf {} +
+rm -rf "$SIGNED_APP_PATH/Contents/_CodeSignature"
+
+codesign --force --deep --sign - "$SIGNED_APP_PATH"
+codesign --verify --deep --strict --verbose=2 "$SIGNED_APP_PATH"
+rm -rf "$APP_PATH"
+ditto --norsrc "$SIGNED_APP_PATH" "$APP_PATH"
+find "$ROOT_DIR/dist" -name '._*' -exec rm -rf {} +
+
+echo "Built and ad-hoc signed: $APP_PATH"

--- a/tools/smoke_inference.py
+++ b/tools/smoke_inference.py
@@ -1,0 +1,1286 @@
+#!/usr/bin/env python3
+"""Real-model smoke tests for the UVR inference backends.
+
+This script intentionally avoids importing UVR.py because that module starts the
+tkinter application. It drives the separator classes directly with a small
+ModelData stand-in and writes JSONL results for later comparison.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+import platform
+import re
+import shutil
+import sys
+import time
+import traceback
+import urllib.error
+import urllib.request
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+ARTIFACT_ROOT = REPO_ROOT / ".research-artifacts" / "smoke"
+
+MODELS_DIR = REPO_ROOT / "models"
+VR_MODELS_DIR = MODELS_DIR / "VR_Models"
+MDX_MODELS_DIR = MODELS_DIR / "MDX_Net_Models"
+DEMUCS_MODELS_DIR = MODELS_DIR / "Demucs_Models"
+DEMUCS_NEWER_REPO_DIR = DEMUCS_MODELS_DIR / "v3_v4_repo"
+VR_HASH_JSON = VR_MODELS_DIR / "model_data" / "model_data.json"
+MDX_HASH_JSON = MDX_MODELS_DIR / "model_data" / "model_data.json"
+MDX_C_CONFIG_PATH = MDX_MODELS_DIR / "model_data" / "mdx_c_configs"
+VR_PARAM_DIR = REPO_ROOT / "lib_v5" / "vr_network" / "modelparams"
+MDX_MIXER_PATH = REPO_ROOT / "lib_v5" / "mixer.ckpt"
+
+NORMAL_REPO = "https://github.com/TRvlvr/model_repo/releases/download/all_public_uvr_models/"
+VR_MODEL_DATA_LINK = (
+    "https://raw.githubusercontent.com/TRvlvr/application_data/main/vr_model_data/model_data_new.json"
+)
+MDX_MODEL_DATA_LINK = (
+    "https://raw.githubusercontent.com/TRvlvr/application_data/main/mdx_model_data/model_data_new.json"
+)
+MDX23_CONFIG_CHECKS = (
+    "https://raw.githubusercontent.com/TRvlvr/application_data/main/mdx_model_data/mdx_c_configs/"
+)
+
+
+def import_constants():
+    from gui_data.constants import (  # noqa: PLC0415
+        ALL_STEMS,
+        BACKEND_AUTO,
+        BACKEND_COREML,
+        BACKEND_CPU,
+        BACKEND_MPS,
+        BASS_STEM,
+        DEFAULT,
+        DEF_OPT,
+        DEMUCS_2_SOURCE,
+        DEMUCS_2_SOURCE_MAPPER,
+        DEMUCS_4_SOURCE,
+        DEMUCS_4_SOURCE_MAPPER,
+        DEMUCS_ARCH_TYPE,
+        DEMUCS_V1,
+        DEMUCS_V2,
+        DEMUCS_V4,
+        DRUM_STEM,
+        FLAC,
+        INST_STEM,
+        LEAD_VOCAL_STEM,
+        MDX_ARCH_TYPE,
+        MP3,
+        OTHER_STEM,
+        PRIMARY_STEM,
+        SECONDARY_STEM,
+        VOCAL_STEM,
+        VR_ARCH_TYPE,
+        WAV,
+        secondary_stem,
+    )
+
+    return {
+        "ALL_STEMS": ALL_STEMS,
+        "BACKEND_AUTO": BACKEND_AUTO,
+        "BACKEND_COREML": BACKEND_COREML,
+        "BACKEND_CPU": BACKEND_CPU,
+        "BACKEND_MPS": BACKEND_MPS,
+        "BASS_STEM": BASS_STEM,
+        "DEFAULT": DEFAULT,
+        "DEF_OPT": DEF_OPT,
+        "DEMUCS_2_SOURCE": DEMUCS_2_SOURCE,
+        "DEMUCS_2_SOURCE_MAPPER": DEMUCS_2_SOURCE_MAPPER,
+        "DEMUCS_4_SOURCE": DEMUCS_4_SOURCE,
+        "DEMUCS_4_SOURCE_MAPPER": DEMUCS_4_SOURCE_MAPPER,
+        "DEMUCS_ARCH_TYPE": DEMUCS_ARCH_TYPE,
+        "DEMUCS_V1": DEMUCS_V1,
+        "DEMUCS_V2": DEMUCS_V2,
+        "DEMUCS_V4": DEMUCS_V4,
+        "DRUM_STEM": DRUM_STEM,
+        "FLAC": FLAC,
+        "INST_STEM": INST_STEM,
+        "LEAD_VOCAL_STEM": LEAD_VOCAL_STEM,
+        "MDX_ARCH_TYPE": MDX_ARCH_TYPE,
+        "MP3": MP3,
+        "OTHER_STEM": OTHER_STEM,
+        "PRIMARY_STEM": PRIMARY_STEM,
+        "SECONDARY_STEM": SECONDARY_STEM,
+        "VOCAL_STEM": VOCAL_STEM,
+        "VR_ARCH_TYPE": VR_ARCH_TYPE,
+        "WAV": WAV,
+        "secondary_stem": secondary_stem,
+    }
+
+
+C = import_constants()
+
+
+@dataclass(frozen=True)
+class DownloadSpec:
+    key: str
+    path: Path
+    url: str
+
+
+DOWNLOADS = {
+    "vr": DownloadSpec("vr", VR_MODELS_DIR / "1_HP-UVR.pth", NORMAL_REPO + "1_HP-UVR.pth"),
+    "mdx": DownloadSpec("mdx", MDX_MODELS_DIR / "UVR_MDXNET_Main.onnx", NORMAL_REPO + "UVR_MDXNET_Main.onnx"),
+    "mdxc": DownloadSpec("mdxc", MDX_MODELS_DIR / "MDX23C_D1581.ckpt", NORMAL_REPO + "MDX23C_D1581.ckpt"),
+    "mdxc_config": DownloadSpec(
+        "mdxc_config",
+        MDX_C_CONFIG_PATH / "model_2_stem_061321.yaml",
+        MDX23_CONFIG_CHECKS + "model_2_stem_061321.yaml",
+    ),
+    "demucs_weight": DownloadSpec(
+        "demucs_weight",
+        DEMUCS_NEWER_REPO_DIR / "955717e8-8726e21a.th",
+        "https://dl.fbaipublicfiles.com/demucs/hybrid_transformer/955717e8-8726e21a.th",
+    ),
+    "demucs_yaml": DownloadSpec(
+        "demucs_yaml",
+        DEMUCS_NEWER_REPO_DIR / "htdemucs.yaml",
+        NORMAL_REPO + "htdemucs.yaml",
+    ),
+}
+
+
+class SmokeError(RuntimeError):
+    pass
+
+
+class MissingAsset(SmokeError):
+    pass
+
+
+class ResultWriter:
+    def __init__(self, path: Path, append: bool = False):
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.file = self.path.open("a" if append else "w", encoding="utf-8")
+
+    def write(self, event: dict):
+        event = {"time": time.strftime("%Y-%m-%dT%H:%M:%S%z"), **event}
+        self.file.write(json.dumps(event, sort_keys=True, ensure_ascii=False) + "\n")
+        self.file.flush()
+
+    def close(self):
+        self.file.close()
+
+
+def read_json_file(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def remove_appledouble_files(root: Path) -> int:
+    if not root.exists():
+        return 0
+    removed = 0
+    for path in root.rglob("._*"):
+        if path.is_file():
+            with contextlib.suppress(OSError):
+                path.unlink()
+                removed += 1
+    return removed
+
+
+def read_json_url(url: str) -> dict:
+    request = urllib.request.Request(url, headers={"User-Agent": "uvr-smoke/1.0"})
+    with urllib.request.urlopen(request, timeout=60) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def model_hash(path: Path) -> str:
+    digest = hashlib.md5()
+    with path.open("rb") as handle:
+        try:
+            handle.seek(-10000 * 1024, os.SEEK_END)
+        except OSError:
+            handle.seek(0)
+        digest.update(handle.read())
+    return digest.hexdigest()
+
+
+def resolve_hash_metadata(path: Path, local_json: Path, remote_url: str | None = None) -> tuple[str, dict | None]:
+    digest = model_hash(path)
+    data = read_json_file(local_json) if local_json.is_file() else {}
+    if digest in data:
+        return digest, data[digest]
+
+    if remote_url:
+        with contextlib.suppress(Exception):
+            remote_data = read_json_url(remote_url)
+            if digest in remote_data:
+                return digest, remote_data[digest]
+
+    return digest, None
+
+
+def download_file(spec: DownloadSpec, force: bool = False) -> dict:
+    spec.path.parent.mkdir(parents=True, exist_ok=True)
+    if spec.path.is_file() and not force:
+        return {"key": spec.key, "path": str(spec.path), "status": "exists", "bytes": spec.path.stat().st_size}
+
+    tmp_path = spec.path.with_suffix(spec.path.suffix + ".part")
+    request = urllib.request.Request(spec.url, headers={"User-Agent": "uvr-smoke/1.0"})
+    started = time.perf_counter()
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response, tmp_path.open("wb") as out:
+            while True:
+                chunk = response.read(1024 * 1024)
+                if not chunk:
+                    break
+                out.write(chunk)
+        tmp_path.replace(spec.path)
+    except Exception:
+        with contextlib.suppress(FileNotFoundError):
+            tmp_path.unlink()
+        raise
+
+    return {
+        "key": spec.key,
+        "path": str(spec.path),
+        "status": "downloaded",
+        "bytes": spec.path.stat().st_size,
+        "elapsed_sec": round(time.perf_counter() - started, 3),
+    }
+
+
+def ensure_assets(download_models: bool, force_download: bool, writer: ResultWriter | None = None):
+    downloads = [
+        DOWNLOADS["vr"],
+        DOWNLOADS["mdx"],
+        DOWNLOADS["mdxc"],
+        DOWNLOADS["mdxc_config"],
+        DOWNLOADS["demucs_weight"],
+        DOWNLOADS["demucs_yaml"],
+    ]
+    for spec in downloads:
+        if download_models:
+            event = download_file(spec, force=force_download)
+            if writer:
+                writer.write({"event": "download", **event})
+        elif not spec.path.is_file():
+            raise MissingAsset(f"Missing {spec.path}. Run: tools/smoke_inference.py prepare")
+
+
+def configure_external_binaries() -> dict:
+    ffmpeg_path = shutil.which("ffmpeg")
+    if ffmpeg_path:
+        os.environ["PATH"] = str(Path(ffmpeg_path).parent) + os.pathsep + os.environ.get("PATH", "")
+        with contextlib.suppress(Exception):
+            import pydub  # noqa: PLC0415
+
+            pydub.AudioSegment.converter = ffmpeg_path
+            pydub.AudioSegment.ffmpeg = ffmpeg_path
+    return {"ffmpeg_path": ffmpeg_path}
+
+
+def generate_input(
+    path: Path,
+    duration: float = 8.0,
+    sample_rate: int = 44100,
+    channels: int = 2,
+    save_format: str | None = None,
+) -> dict:
+    import numpy as np  # noqa: PLC0415
+    import soundfile as sf  # noqa: PLC0415
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    samples = int(duration * sample_rate)
+    t = np.arange(samples, dtype=np.float32) / sample_rate
+    envelope = np.linspace(0.2, 0.9, samples, dtype=np.float32)
+    left = 0.18 * np.sin(2 * np.pi * 220.0 * t) + 0.06 * np.sin(2 * np.pi * 880.0 * t)
+    right = 0.16 * np.sin(2 * np.pi * 330.0 * t) + 0.05 * np.sin(2 * np.pi * 660.0 * t)
+    if channels == 1:
+        audio = (left * envelope).astype(np.float32)
+    else:
+        audio = np.stack([left * envelope, right * envelope], axis=1).astype(np.float32)
+
+    fmt = (save_format or path.suffix.lstrip(".") or "wav").lower()
+    if fmt == "mp3":
+        import pydub  # noqa: PLC0415
+
+        configure_external_binaries()
+        wav_buffer = path.with_suffix(".tmp.wav")
+        sf.write(wav_buffer, audio, sample_rate, subtype="PCM_16")
+        try:
+            pydub.AudioSegment.from_wav(wav_buffer).export(path, format="mp3", bitrate="192k")
+        finally:
+            with contextlib.suppress(FileNotFoundError):
+                wav_buffer.unlink()
+    else:
+        sf.write(path, audio, sample_rate, subtype="PCM_16", format=fmt.upper())
+    return {
+        "path": str(path),
+        "duration_sec": duration,
+        "sample_rate": sample_rate,
+        "samples": samples,
+        "channels": channels,
+        "format": fmt.upper(),
+    }
+
+
+class SmokeModelData:
+    """Small stand-in for UVR.ModelData used by separate.py."""
+
+    def __init__(
+        self,
+        key: str,
+        backend_mode: str,
+        save_format: str,
+        is_secondary_model: bool = False,
+        primary_model_primary_stem: str | None = None,
+        is_vocal_split_model: bool = False,
+        gpu_enabled: bool = True,
+        demucs_version: str | None = None,
+    ):
+        from lib_v5.vr_network.model_param_init import ModelParameters  # noqa: PLC0415
+        from ml_collections import ConfigDict  # noqa: PLC0415
+        import yaml  # noqa: PLC0415
+
+        secondary_stem = C["secondary_stem"]
+
+        self.key = key
+        self.DENOISER_MODEL = str(VR_MODELS_DIR / "UVR-DeNoise-Lite.pth")
+        self.DEVERBER_MODEL = str(VR_MODELS_DIR / "UVR-DeEcho-DeReverb.pth")
+        self.is_deverb_vocals = False
+        self.deverb_vocal_opt = C["VOCAL_STEM"]
+        self.is_denoise_model = False
+        self.is_gpu_conversion = 0 if gpu_enabled else -1
+        self.backend_mode = backend_mode
+        self.is_normalization = False
+        self.is_use_opencl = False
+        self.is_primary_stem_only = False
+        self.is_secondary_stem_only = False
+        self.is_denoise = False
+        self.is_mdx_c_seg_def = True
+        self.mdx_batch_size = 1
+        self.mdxnet_stem_select = C["VOCAL_STEM"]
+        self.overlap = 0.25
+        self.overlap_mdx = 0.25
+        self.overlap_mdx23 = 8
+        self.semitone_shift = 0.0
+        self.is_pitch_change = False
+        self.is_match_frequency_pitch = True
+        self.is_mdx_ckpt = False
+        self.is_mdx_c = False
+        self.is_mdx_combine_stems = True
+        self.mdx_c_configs = None
+        self.mdx_model_stems = []
+        self.mdx_dim_f_set = None
+        self.mdx_dim_t_set = None
+        self.mdx_stem_count = 1
+        self.compensate = 1.0
+        self.mdx_n_fft_scale_set = None
+        self.wav_type_set = "PCM_16"
+        self.device_set = C["DEFAULT"]
+        self.mp3_bit_set = "320k"
+        self.save_format = save_format
+        self.is_invert_spec = False
+        self.is_mixer_mode = False
+        self.demucs_stems = C["ALL_STEMS"]
+        self.is_demucs_combine_stems = True
+        self.demucs_source_list = []
+        self.demucs_stem_count = 0
+        self.mixer_path = str(MDX_MIXER_PATH)
+        self.process_method = None
+        self.model_status = True
+        self.primary_stem = None
+        self.secondary_stem = None
+        self.primary_stem_native = None
+        self.is_ensemble_mode = False
+        self.ensemble_primary_stem = None
+        self.ensemble_secondary_stem = None
+        self.primary_model_primary_stem = primary_model_primary_stem
+        self.is_secondary_model = True if is_vocal_split_model else is_secondary_model
+        self.secondary_model = None
+        self.secondary_model_scale = 0.9
+        self.demucs_4_stem_added_count = 0
+        self.is_demucs_4_stem_secondaries = False
+        self.is_4_stem_ensemble = False
+        self.pre_proc_model = None
+        self.pre_proc_model_activated = False
+        self.is_pre_proc_model = False
+        self.model_samplerate = 44100
+        self.model_capacity = 32, 128
+        self.is_vr_51_model = False
+        self.is_demucs_pre_proc_model_inst_mix = False
+        self.secondary_model_4_stem = []
+        self.secondary_model_4_stem_scale = []
+        self.secondary_model_4_stem_names = []
+        self.secondary_model_4_stem_model_names_list = []
+        self.is_multi_stem_ensemble = False
+        self.is_karaoke = False
+        self.is_bv_model = False
+        self.bv_model_rebalance = 0
+        self.is_sec_bv_rebalance = False
+        self.is_secondary_model_activated = False
+        self.vocal_split_model = None
+        self.is_vocal_split_model = is_vocal_split_model
+        self.is_vocal_split_model_activated = False
+        self.is_save_inst_vocal_splitter = False
+        self.is_inst_only_voc_splitter = False
+        self.is_save_vocal_only = False
+        self.is_primary_model_primary_stem_only = False
+        self.is_primary_model_secondary_stem_only = False
+
+        if key == "vr":
+            self.process_method = C["VR_ARCH_TYPE"]
+            self.model_path = str(DOWNLOADS["vr"].path)
+            digest, metadata = resolve_hash_metadata(Path(self.model_path), VR_HASH_JSON, VR_MODEL_DATA_LINK)
+            if not metadata:
+                raise MissingAsset(f"VR metadata not found for {self.model_path} hash {digest}.")
+            param_path = VR_PARAM_DIR / f"{metadata['vr_model_param']}.json"
+            self.model_name = Path(self.model_path).stem
+            self.model_basename = Path(self.model_path).stem
+            self.primary_stem = metadata["primary_stem"]
+            self.primary_stem_native = self.primary_stem
+            self.secondary_stem = secondary_stem(self.primary_stem)
+            self.vr_model_param = ModelParameters(str(param_path))
+            self.model_samplerate = self.vr_model_param.param["sr"]
+            self.is_vr_51_model = "nout" in metadata and "nout_lstm" in metadata
+            if self.is_vr_51_model:
+                self.model_capacity = metadata["nout"], metadata["nout_lstm"]
+            self.is_karaoke = bool(metadata.get("is_karaoke", False))
+            self.is_bv_model = bool(metadata.get("is_bv_model", False))
+            self.bv_model_rebalance = metadata.get("is_bv_model_rebalanced", 0)
+            self.aggression_setting = 0.05
+            self.is_tta = False
+            self.is_post_process = False
+            self.window_size = 512
+            self.batch_size = 1
+            self.crop_size = 256
+            self.is_high_end_process = "none"
+            self.post_process_threshold = 0.2
+
+        elif key == "mdx":
+            self.process_method = C["MDX_ARCH_TYPE"]
+            self.model_path = str(DOWNLOADS["mdx"].path)
+            digest, metadata = resolve_hash_metadata(Path(self.model_path), MDX_HASH_JSON, MDX_MODEL_DATA_LINK)
+            if not metadata:
+                raise MissingAsset(f"MDX metadata not found for {self.model_path} hash {digest}.")
+            self.model_name = Path(self.model_path).stem
+            self.model_basename = Path(self.model_path).stem
+            self.compensate = metadata["compensate"]
+            self.mdx_dim_f_set = metadata["mdx_dim_f_set"]
+            self.mdx_dim_t_set = metadata["mdx_dim_t_set"]
+            self.mdx_n_fft_scale_set = metadata["mdx_n_fft_scale_set"]
+            self.mdx_segment_size = 256
+            self.chunks = 0
+            self.margin = 44100
+            self.primary_stem = metadata["primary_stem"]
+            self.primary_stem_native = self.primary_stem
+            self.secondary_stem = secondary_stem(self.primary_stem)
+
+        elif key == "mdxc":
+            self.process_method = C["MDX_ARCH_TYPE"]
+            self.model_path = str(DOWNLOADS["mdxc"].path)
+            _, metadata = resolve_hash_metadata(Path(self.model_path), MDX_HASH_JSON, MDX_MODEL_DATA_LINK)
+            if not metadata:
+                metadata = {"config_yaml": "model_2_stem_061321.yaml"}
+            config_path = MDX_C_CONFIG_PATH / metadata["config_yaml"]
+            with config_path.open("r", encoding="utf-8") as handle:
+                config = ConfigDict(yaml.load(handle, Loader=yaml.FullLoader))
+            self.is_mdx_ckpt = True
+            self.is_mdx_c = True
+            self.mdx_c_configs = config
+            self.model_name = Path(self.model_path).name
+            self.model_basename = Path(self.model_path).stem
+            self.mdx_segment_size = int(config.inference.dim_t)
+            self.chunks = 0
+            self.margin = 44100
+            self.mdx_n_fft_scale_set = int(config.audio.n_fft)
+            if config.training.target_instrument:
+                self.mdx_model_stems = [config.training.target_instrument]
+                self.primary_stem = config.training.target_instrument
+            else:
+                self.mdx_model_stems = list(config.training.instruments)
+                self.primary_stem = self.mdxnet_stem_select
+            self.mdx_stem_count = len(self.mdx_model_stems)
+            self.primary_stem_native = self.primary_stem
+            self.secondary_stem = secondary_stem(self.primary_stem)
+
+        elif key == "demucs":
+            self.process_method = C["DEMUCS_ARCH_TYPE"]
+            self.model_path = str(DOWNLOADS["demucs_yaml"].path)
+            self.model_name = "v4 | htdemucs"
+            self.model_basename = Path(self.model_path).stem
+            self.demucs_version = demucs_version or C["DEMUCS_V4"]
+            if self.demucs_version in {C["DEMUCS_V1"], C["DEMUCS_V2"]}:
+                self.demucs_source_list = C["DEMUCS_2_SOURCE"]
+                self.demucs_source_map = C["DEMUCS_2_SOURCE_MAPPER"]
+                self.demucs_stem_count = 2
+            else:
+                self.demucs_source_list = C["DEMUCS_4_SOURCE"]
+                self.demucs_source_map = C["DEMUCS_4_SOURCE_MAPPER"]
+                self.demucs_stem_count = 4
+            self.primary_stem = C["PRIMARY_STEM"]
+            self.secondary_stem = C["SECONDARY_STEM"]
+            self.shifts = 0
+            self.is_split_mode = True
+            self.segment = C["DEF_OPT"]
+            self.is_chunk_demucs = False
+        else:
+            raise ValueError(f"Unknown model key: {key}")
+
+        if self.is_vocal_split_model:
+            primary = C["LEAD_VOCAL_STEM"] if self.primary_stem_native == C["VOCAL_STEM"] else "backing_only"
+            self.primary_stem = primary
+            self.secondary_stem = secondary_stem(primary)
+
+
+@dataclass(frozen=True)
+class SmokeCase:
+    case_id: str
+    model_key: str
+    backend_mode: str
+    save_format: str
+    expected_stems: tuple[str, ...]
+    secondary_key: str | None = None
+    vocal_splitter_key: str | None = None
+    gpu_enabled: bool = True
+    expected_backend_label: str | None = None
+    expected_runner_contains: str | None = None
+    demucs_version: str | None = None
+    duration: float | None = None
+    input_format: str = "wav"
+    input_channels: int = 2
+
+
+def blocking_cases() -> list[SmokeCase]:
+    return [
+        SmokeCase("vr_auto", "vr", C["BACKEND_AUTO"], C["WAV"], (C["INST_STEM"], C["VOCAL_STEM"])),
+        SmokeCase("vr_cpu", "vr", C["BACKEND_CPU"], C["WAV"], (C["INST_STEM"], C["VOCAL_STEM"])),
+        SmokeCase("mdx_auto", "mdx", C["BACKEND_AUTO"], C["WAV"], (C["VOCAL_STEM"], C["INST_STEM"])),
+        SmokeCase("mdx_cpu", "mdx", C["BACKEND_CPU"], C["WAV"], (C["VOCAL_STEM"], C["INST_STEM"])),
+        SmokeCase("mdx_coreml", "mdx", C["BACKEND_COREML"], C["WAV"], (C["VOCAL_STEM"], C["INST_STEM"])),
+        SmokeCase("mdxc_auto", "mdxc", C["BACKEND_AUTO"], C["WAV"], (C["VOCAL_STEM"], C["INST_STEM"])),
+        SmokeCase("mdxc_cpu", "mdxc", C["BACKEND_CPU"], C["WAV"], (C["VOCAL_STEM"], C["INST_STEM"])),
+        SmokeCase(
+            "demucs_auto",
+            "demucs",
+            C["BACKEND_AUTO"],
+            C["WAV"],
+            (C["BASS_STEM"], C["DRUM_STEM"], C["OTHER_STEM"], C["VOCAL_STEM"]),
+        ),
+    ]
+
+
+def backend_mode_cases() -> list[SmokeCase]:
+    return [
+        SmokeCase("vr_mps", "vr", C["BACKEND_MPS"], C["WAV"], (C["INST_STEM"], C["VOCAL_STEM"]), expected_backend_label=C["BACKEND_MPS"]),
+        SmokeCase(
+            "mdx_mps",
+            "mdx",
+            C["BACKEND_MPS"],
+            C["WAV"],
+            (C["VOCAL_STEM"], C["INST_STEM"]),
+            expected_backend_label=C["BACKEND_MPS"],
+            expected_runner_contains="ONNX converted to PyTorch",
+        ),
+        SmokeCase("mdxc_mps", "mdxc", C["BACKEND_MPS"], C["WAV"], (C["VOCAL_STEM"], C["INST_STEM"]), expected_backend_label=C["BACKEND_MPS"]),
+        SmokeCase(
+            "demucs_mps",
+            "demucs",
+            C["BACKEND_MPS"],
+            C["WAV"],
+            (C["BASS_STEM"], C["DRUM_STEM"], C["OTHER_STEM"], C["VOCAL_STEM"]),
+            expected_backend_label=C["BACKEND_MPS"],
+        ),
+        SmokeCase(
+            "demucs_cpu",
+            "demucs",
+            C["BACKEND_CPU"],
+            C["WAV"],
+            (C["BASS_STEM"], C["DRUM_STEM"], C["OTHER_STEM"], C["VOCAL_STEM"]),
+            expected_backend_label=C["BACKEND_CPU"],
+        ),
+    ]
+
+
+def gpu_disabled_cases() -> list[SmokeCase]:
+    return [
+        SmokeCase(
+            "gpu_disabled_auto_vr",
+            "vr",
+            C["BACKEND_AUTO"],
+            C["WAV"],
+            (C["INST_STEM"], C["VOCAL_STEM"]),
+            gpu_enabled=False,
+            expected_backend_label=C["BACKEND_CPU"],
+        ),
+        SmokeCase(
+            "gpu_disabled_mps_mdx",
+            "mdx",
+            C["BACKEND_MPS"],
+            C["WAV"],
+            (C["VOCAL_STEM"], C["INST_STEM"]),
+            gpu_enabled=False,
+            expected_backend_label=C["BACKEND_CPU"],
+            expected_runner_contains="ONNX Runtime",
+        ),
+    ]
+
+
+def demucs_legacy_cases() -> list[SmokeCase]:
+    return [
+        SmokeCase(
+            "demucs_v1_auto_policy",
+            "demucs",
+            C["BACKEND_AUTO"],
+            C["WAV"],
+            (C["INST_STEM"], C["VOCAL_STEM"]),
+            expected_backend_label=C["BACKEND_CPU"],
+            demucs_version=C["DEMUCS_V1"],
+        ),
+        SmokeCase(
+            "demucs_v2_mps_policy",
+            "demucs",
+            C["BACKEND_MPS"],
+            C["WAV"],
+            (C["INST_STEM"], C["VOCAL_STEM"]),
+            expected_backend_label=C["BACKEND_CPU"],
+            demucs_version=C["DEMUCS_V2"],
+        ),
+    ]
+
+
+def format_input_cases() -> list[SmokeCase]:
+    return [
+        SmokeCase("input_flac_vr_auto", "vr", C["BACKEND_AUTO"], C["WAV"], (C["INST_STEM"], C["VOCAL_STEM"]), input_format="flac"),
+        SmokeCase("input_mp3_mdx_cpu", "mdx", C["BACKEND_CPU"], C["WAV"], (C["VOCAL_STEM"], C["INST_STEM"]), input_format="mp3"),
+        SmokeCase("input_mono_vr_cpu", "vr", C["BACKEND_CPU"], C["WAV"], (C["INST_STEM"], C["VOCAL_STEM"]), input_channels=1),
+    ]
+
+
+def long_audio_cases() -> list[SmokeCase]:
+    return [
+        SmokeCase("long_60s_mdx_mps", "mdx", C["BACKEND_MPS"], C["WAV"], (C["VOCAL_STEM"], C["INST_STEM"]), duration=60.0),
+        SmokeCase("long_180s_vr_cpu", "vr", C["BACKEND_CPU"], C["WAV"], (C["INST_STEM"], C["VOCAL_STEM"]), duration=180.0),
+    ]
+
+
+def extended_cases() -> list[SmokeCase]:
+    return [
+        SmokeCase(
+            "secondary_vr_mdx",
+            "vr",
+            C["BACKEND_AUTO"],
+            C["WAV"],
+            (C["INST_STEM"], C["VOCAL_STEM"]),
+            secondary_key="mdx",
+        ),
+        SmokeCase(
+            "vocal_split_mdx_vr",
+            "mdx",
+            C["BACKEND_AUTO"],
+            C["WAV"],
+            (C["VOCAL_STEM"], C["INST_STEM"]),
+            vocal_splitter_key="vr",
+        ),
+        SmokeCase("format_flac_vr_cpu", "vr", C["BACKEND_CPU"], C["FLAC"], (C["INST_STEM"], C["VOCAL_STEM"])),
+        SmokeCase("format_mp3_vr_cpu", "vr", C["BACKEND_CPU"], C["MP3"], (C["INST_STEM"], C["VOCAL_STEM"])),
+    ]
+
+
+def make_process_data(input_path: Path, audio_base: str, export_path: Path, model_names: list[str]) -> tuple[dict, list[str]]:
+    console: list[str] = []
+    cache: dict[tuple[str, str | None], object] = {}
+    progress = {"value": 0, "calls": 0}
+
+    def set_progress_bar(base, value=None):
+        progress["calls"] += 1
+        progress["value"] = value if value is not None else base
+
+    def write_to_console(text, base_text=None):
+        console.append(str(text))
+
+    def cached_source_callback(process_method, model_name=None):
+        key = (process_method, model_name)
+        if key in cache:
+            return model_name, cache[key]
+        return None, None
+
+    def cached_model_source_holder(process_method, sources, model_name=None):
+        cache[(process_method, model_name)] = sources
+
+    iteration = {"count": 0}
+
+    def process_iteration():
+        iteration["count"] += 1
+
+    return (
+        {
+            "audio_file": str(input_path),
+            "audio_file_base": audio_base,
+            "export_path": str(export_path),
+            "cached_source_callback": cached_source_callback,
+            "cached_model_source_holder": cached_model_source_holder,
+            "is_4_stem_ensemble": False,
+            "list_all_models": model_names,
+            "process_iteration": process_iteration,
+            "set_progress_bar": set_progress_bar,
+            "write_to_console": write_to_console,
+            "is_ensemble_master": False,
+        },
+        console,
+    )
+
+
+def build_separator(model_data: SmokeModelData, process_data: dict):
+    from separate import SeperateDemucs, SeperateMDX, SeperateMDXC, SeperateVR  # noqa: PLC0415
+
+    if model_data.process_method == C["VR_ARCH_TYPE"]:
+        return SeperateVR(model_data, process_data)
+    if model_data.process_method == C["MDX_ARCH_TYPE"] and model_data.is_mdx_c:
+        return SeperateMDXC(model_data, process_data)
+    if model_data.process_method == C["MDX_ARCH_TYPE"]:
+        return SeperateMDX(model_data, process_data)
+    if model_data.process_method == C["DEMUCS_ARCH_TYPE"]:
+        return SeperateDemucs(model_data, process_data)
+    raise ValueError(f"Unsupported process method: {model_data.process_method}")
+
+
+def output_extension(save_format: str) -> str:
+    if save_format == C["FLAC"]:
+        return ".flac"
+    if save_format == C["MP3"]:
+        return ".mp3"
+    return ".wav"
+
+
+def case_input_path(default_input: Path, case: SmokeCase, artifact_dir: Path) -> Path:
+    if case.duration is None and case.input_format == "wav" and case.input_channels == 2:
+        return default_input
+    suffix = "." + case.input_format.lower()
+    name = case.case_id + suffix
+    return artifact_dir / "input" / name
+
+
+def validate_audio(path: Path) -> dict:
+    import numpy as np  # noqa: PLC0415
+    import soundfile as sf  # noqa: PLC0415
+
+    if not path.is_file():
+        raise AssertionError(f"Missing output {path}")
+    data, sample_rate = sf.read(path, always_2d=True)
+    if sample_rate != 44100:
+        raise AssertionError(f"{path} sample rate is {sample_rate}, expected 44100")
+    if data.shape[1] != 2:
+        raise AssertionError(f"{path} channel count is {data.shape[1]}, expected stereo")
+    if not np.isfinite(data).all():
+        raise AssertionError(f"{path} contains NaN or inf")
+    peak = float(np.max(np.abs(data))) if data.size else 0.0
+    if peak <= 1e-8:
+        raise AssertionError(f"{path} is silent")
+    return {
+        "path": str(path),
+        "sample_rate": sample_rate,
+        "shape": list(data.shape),
+        "peak": peak,
+        "duration_sec": round(data.shape[0] / sample_rate, 3),
+    }
+
+
+def parse_model_load_sec(console_text: str) -> float | None:
+    match = re.search(r"Model load:\s*([0-9.]+)s", console_text)
+    return float(match.group(1)) if match else None
+
+
+def run_backend_policy_case(case: SmokeCase, writer: ResultWriter) -> bool:
+    from inference_backend import plan_backend  # noqa: PLC0415
+
+    model = SmokeModelData(
+        case.model_key,
+        case.backend_mode,
+        case.save_format,
+        gpu_enabled=case.gpu_enabled,
+        demucs_version=case.demucs_version,
+    )
+    plan = plan_backend(
+        model.backend_mode,
+        model.is_gpu_conversion >= 0,
+        model.device_set,
+        process_method=model.process_method,
+        demucs_version=getattr(model, "demucs_version", None),
+    )
+    result = {
+        "event": "case",
+        "case_id": case.case_id,
+        "model_key": case.model_key,
+        "backend_mode": case.backend_mode,
+        "save_format": case.save_format,
+        "gpu_enabled": case.gpu_enabled,
+        "demucs_version": case.demucs_version,
+        "status": "failed",
+        "backend_label": plan.label,
+        "runner_label": None,
+        "fallback": plan.fallback_to_cpu,
+        "model_load_sec": None,
+        "elapsed_sec": 0,
+        "outputs": [],
+        "console_tail": f"Backend policy: {plan.label}",
+    }
+    try:
+        if case.expected_backend_label and plan.label != case.expected_backend_label:
+            raise AssertionError(f"Expected backend {case.expected_backend_label}, got {plan.label}")
+        result["status"] = "passed"
+        writer.write(result)
+        return True
+    except Exception as exc:
+        result.update({"exception": repr(exc), "traceback": traceback.format_exc()})
+        writer.write(result)
+        return False
+
+
+def run_case(case: SmokeCase, input_path: Path, artifact_dir: Path, writer: ResultWriter) -> bool:
+    from inference_backend import clear_backend_cache  # noqa: PLC0415
+
+    if case.demucs_version in {C["DEMUCS_V1"], C["DEMUCS_V2"]}:
+        return run_backend_policy_case(case, writer)
+
+    export_dir = artifact_dir / "outputs" / case.case_id
+    export_dir.mkdir(parents=True, exist_ok=True)
+    audio_base = case.case_id
+
+    for old in export_dir.glob(f"{audio_base}_*"):
+        if old.is_file():
+            old.unlink()
+
+    model = SmokeModelData(
+        case.model_key,
+        case.backend_mode,
+        case.save_format,
+        gpu_enabled=case.gpu_enabled,
+        demucs_version=case.demucs_version,
+    )
+    model_names = [model.model_basename]
+
+    if case.secondary_key:
+        secondary = SmokeModelData(
+            case.secondary_key,
+            case.backend_mode,
+            case.save_format,
+            is_secondary_model=True,
+            primary_model_primary_stem=model.primary_stem,
+            gpu_enabled=case.gpu_enabled,
+        )
+        model.secondary_model = secondary
+        model.secondary_model_scale = 0.9
+        model.is_secondary_model_activated = True
+        model_names.append(secondary.model_basename)
+
+    if case.vocal_splitter_key:
+        splitter = SmokeModelData(
+            case.vocal_splitter_key,
+            case.backend_mode,
+            case.save_format,
+            is_vocal_split_model=True,
+            gpu_enabled=case.gpu_enabled,
+        )
+        model.vocal_split_model = splitter
+        model.is_vocal_split_model_activated = True
+        model_names.append(splitter.model_basename)
+
+    process_data, console = make_process_data(input_path, audio_base, export_dir, model_names)
+    result = {
+        "event": "case",
+        "case_id": case.case_id,
+        "model_key": case.model_key,
+        "backend_mode": case.backend_mode,
+        "save_format": case.save_format,
+        "gpu_enabled": case.gpu_enabled,
+        "input_path": str(input_path),
+        "input_format": case.input_format,
+        "input_channels": case.input_channels,
+        "status": "failed",
+        "backend_label": None,
+        "runner_label": None,
+        "fallback": None,
+        "model_load_sec": None,
+        "elapsed_sec": None,
+        "outputs": [],
+        "console_tail": "",
+    }
+
+    started = time.perf_counter()
+    try:
+        separator = build_separator(model, process_data)
+        separator.seperate()
+        elapsed = time.perf_counter() - started
+        console_text = "".join(console)
+        model_load_sec = parse_model_load_sec(console_text)
+        ext = output_extension(case.save_format)
+        outputs = [
+            validate_audio(export_dir / f"{audio_base}_({stem}){ext}")
+            for stem in case.expected_stems
+        ]
+        if "Backend:" not in console_text:
+            raise AssertionError("Console log did not include backend instrumentation")
+        if case.expected_backend_label and separator.backend_plan.label != case.expected_backend_label:
+            raise AssertionError(f"Expected backend {case.expected_backend_label}, got {separator.backend_plan.label}")
+        if case.expected_runner_contains and case.expected_runner_contains not in str(separator.model_runner_label):
+            raise AssertionError(
+                f"Expected runner containing {case.expected_runner_contains!r}, got {separator.model_runner_label!r}"
+            )
+
+        result.update(
+            {
+                "status": "passed",
+                "elapsed_sec": round(elapsed, 3),
+                "model_load_sec": model_load_sec,
+                "inference_and_save_sec": round(elapsed - model_load_sec, 3) if model_load_sec is not None else None,
+                "backend_label": separator.backend_plan.label,
+                "runner_label": separator.model_runner_label,
+                "fallback": separator.backend_plan.fallback_to_cpu or "falling back to CPU" in console_text,
+                "outputs": outputs,
+                "console_tail": console_text[-2000:],
+            }
+        )
+        writer.write(result)
+        cleanup_appledouble()
+        clear_backend_cache()
+        return True
+    except Exception as exc:
+        result.update(
+            {
+                "elapsed_sec": round(time.perf_counter() - started, 3),
+                "exception": repr(exc),
+                "traceback": traceback.format_exc(),
+                "console_tail": "".join(console)[-2000:],
+            }
+        )
+        writer.write(result)
+        cleanup_appledouble()
+        clear_backend_cache()
+        return False
+
+
+def run_ensemble_smoke(artifact_dir: Path, writer: ResultWriter) -> bool:
+    from lib_v5 import spec_utils  # noqa: PLC0415
+
+    source_a = artifact_dir / "outputs" / "vr_cpu" / f"vr_cpu_({C['VOCAL_STEM']}).wav"
+    source_b = artifact_dir / "outputs" / "mdx_cpu" / f"mdx_cpu_({C['VOCAL_STEM']}).wav"
+    output = artifact_dir / "outputs" / "ensemble" / "ensemble_vocals.wav"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    result = {"event": "case", "case_id": "ensemble_vocals", "status": "failed"}
+    try:
+        if not source_a.is_file() or not source_b.is_file():
+            raise MissingAsset("Ensemble smoke requires vr_cpu and mdx_cpu outputs from blocking phase.")
+        spec_utils.ensemble_inputs(
+            [str(source_a), str(source_b)],
+            "Average",
+            False,
+            "PCM_16",
+            str(output),
+            is_wave=False,
+        )
+        result.update({"status": "passed", "outputs": [validate_audio(output)]})
+        writer.write(result)
+        return True
+    except Exception as exc:
+        result.update({"exception": repr(exc), "traceback": traceback.format_exc()})
+        writer.write(result)
+        return False
+
+
+def summarize_results(results_path: Path, writer: ResultWriter | None = None) -> dict:
+    latest: dict[str, dict] = {}
+    if results_path.is_file():
+        for line in results_path.read_text(encoding="utf-8", errors="replace").splitlines():
+            if not line.strip().startswith("{"):
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if event.get("event") == "case":
+                latest[event.get("case_id", "")] = event
+
+    cases = []
+    performance_pairs = {}
+    for case_id, event in sorted(latest.items()):
+        cases.append(
+            {
+                "case_id": case_id,
+                "status": event.get("status"),
+                "backend_label": event.get("backend_label"),
+                "runner_label": event.get("runner_label"),
+                "fallback": event.get("fallback"),
+                "elapsed_sec": event.get("elapsed_sec"),
+                "model_load_sec": event.get("model_load_sec"),
+                "exception": event.get("exception"),
+            }
+        )
+
+    pair_map = {
+        "vr": ("vr_auto", "vr_cpu"),
+        "mdx": ("mdx_auto", "mdx_cpu"),
+        "mdxc": ("mdxc_auto", "mdxc_cpu"),
+        "demucs_v4": ("demucs_auto", "demucs_cpu"),
+    }
+    for name, (gpu_case, cpu_case) in pair_map.items():
+        gpu = latest.get(gpu_case)
+        cpu = latest.get(cpu_case)
+        if gpu and cpu and gpu.get("elapsed_sec") and cpu.get("elapsed_sec"):
+            performance_pairs[name] = {
+                "gpu_case": gpu_case,
+                "cpu_case": cpu_case,
+                "gpu_elapsed_sec": gpu.get("elapsed_sec"),
+                "cpu_elapsed_sec": cpu.get("elapsed_sec"),
+                "gpu_vs_cpu_ratio": round(float(gpu["elapsed_sec"]) / float(cpu["elapsed_sec"]), 3),
+            }
+
+    summary = {
+        "event": "summary",
+        "case_count": len(cases),
+        "passed": sum(1 for case in cases if case["status"] == "passed"),
+        "failed": [case for case in cases if case["status"] != "passed"],
+        "performance_pairs": performance_pairs,
+    }
+    if writer:
+        writer.write(summary)
+    return summary
+
+
+def probe_backends(writer: ResultWriter | None = None) -> dict:
+    from inference_backend import cuda_available, mps_available, plan_backend  # noqa: PLC0415
+
+    probes = []
+    for mode in [C["BACKEND_AUTO"], C["BACKEND_MPS"], C["BACKEND_COREML"], C["BACKEND_CPU"]]:
+        plan = plan_backend(mode, True)
+        probes.append(
+            {
+                "mode": mode,
+                "label": plan.label,
+                "torch_backend": plan.torch_backend,
+                "torch_device": str(plan.torch_device),
+                "onnx_providers": [p[0] if isinstance(p, tuple) else p for p in plan.onnx_providers],
+                "prefer_onnx2torch": plan.prefer_onnx2torch,
+                "fallback_to_cpu": plan.fallback_to_cpu,
+                "supports_stft": plan.supports_stft,
+                "supports_complex": plan.supports_complex,
+            }
+        )
+
+    event = {
+        "event": "backend_probe",
+        "platform": platform.platform(),
+        "python": sys.version,
+        "cuda_available": cuda_available,
+        "mps_available": mps_available,
+        "probes": probes,
+    }
+    if writer:
+        writer.write(event)
+    return event
+
+
+def doctor(writer: ResultWriter | None = None) -> dict:
+    report = {
+        "event": "doctor",
+        "python": sys.version,
+        "executable": sys.executable,
+        "platform": platform.platform(),
+        "imports": {},
+        "ffmpeg_path": shutil.which("ffmpeg"),
+        "repo_ffmpeg_path": str(REPO_ROOT / "ffmpeg") if (REPO_ROOT / "ffmpeg").exists() else None,
+    }
+    for module in ["torch", "onnxruntime", "onnx2pytorch", "soundfile", "librosa", "ml_collections"]:
+        try:
+            imported = __import__(module)
+            report["imports"][module] = getattr(imported, "__version__", "ok")
+        except Exception as exc:
+            report["imports"][module] = f"ERROR: {exc!r}"
+    with contextlib.suppress(Exception):
+        import torch  # noqa: PLC0415
+
+        report["torch_mps_available"] = bool(
+            hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+        )
+        report["torch_cuda_available"] = bool(torch.cuda.is_available())
+    with contextlib.suppress(Exception):
+        import onnxruntime as ort  # noqa: PLC0415
+
+        report["onnxruntime_providers"] = ort.get_available_providers()
+    if writer:
+        writer.write(report)
+    return report
+
+
+def selected_cases(phase: str) -> list[SmokeCase]:
+    if phase == "blocking":
+        return blocking_cases()
+    if phase == "extended":
+        return extended_cases()
+    if phase == "backend_modes":
+        return backend_mode_cases()
+    if phase == "gpu_disabled":
+        return gpu_disabled_cases()
+    if phase == "demucs_legacy":
+        return demucs_legacy_cases()
+    if phase == "format_inputs":
+        return format_input_cases()
+    if phase == "long_audio":
+        return long_audio_cases()
+    if phase == "all":
+        return (
+            blocking_cases()
+            + extended_cases()
+            + backend_mode_cases()
+            + gpu_disabled_cases()
+            + demucs_legacy_cases()
+            + format_input_cases()
+            + long_audio_cases()
+        )
+    raise ValueError(f"Unknown phase {phase}")
+
+
+def command_prepare(args, writer: ResultWriter) -> int:
+    input_info = generate_input(args.input, args.duration)
+    writer.write({"event": "input", **input_info})
+    ensure_assets(not args.skip_download, args.force_download, writer)
+    return 0
+
+
+def command_probe(args, writer: ResultWriter) -> int:
+    print(json.dumps(probe_backends(writer), indent=2, ensure_ascii=False))
+    return 0
+
+
+def command_doctor(args, writer: ResultWriter) -> int:
+    cleanup_appledouble(writer)
+    writer.write({"event": "external_binaries", **configure_external_binaries()})
+    report = doctor(writer)
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    failed = [name for name, value in report["imports"].items() if str(value).startswith("ERROR:")]
+    return 1 if failed else 0
+
+
+def command_run(args, writer: ResultWriter) -> int:
+    cleanup_appledouble(writer)
+    writer.write({"event": "external_binaries", **configure_external_binaries()})
+    ensure_assets(False, False, writer)
+    if not args.input.is_file():
+        generate_input(args.input, args.duration)
+    cases = selected_cases(args.phase)
+    if args.case:
+        wanted = set(args.case.split(","))
+        cases = [case for case in cases if case.case_id in wanted]
+    ok = True
+    for case in cases:
+        input_path = case_input_path(args.input, case, args.artifact_dir)
+        if not input_path.is_file():
+            generate_input(
+                input_path,
+                duration=case.duration or args.duration,
+                channels=case.input_channels,
+                save_format=case.input_format,
+            )
+        case_ok = run_case(case, input_path, args.artifact_dir, writer)
+        ok = ok and case_ok
+        if not case_ok and not args.continue_on_error:
+            break
+    if ok and args.phase in {"extended", "all"}:
+        ok = run_ensemble_smoke(args.artifact_dir, writer) and ok
+    return 0 if ok else 1
+
+
+def command_all(args, writer: ResultWriter) -> int:
+    prepare_status = command_prepare(args, writer)
+    if prepare_status:
+        return prepare_status
+    doctor_status = command_doctor(args, writer)
+    if doctor_status and not args.continue_on_error:
+        return doctor_status
+    command_probe(args, writer)
+    return command_run(args, writer)
+
+
+def command_summary(args, writer: ResultWriter) -> int:
+    summary = summarize_results(args.results, writer)
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+    return 0 if not summary["failed"] else 1
+
+
+def cleanup_appledouble(writer: ResultWriter | None = None):
+    prefix = Path(sys.prefix).resolve()
+    venv_removed = remove_appledouble_files(prefix) if prefix.is_relative_to(REPO_ROOT) else 0
+    removed = {
+        "artifacts": remove_appledouble_files(ARTIFACT_ROOT),
+        "models": remove_appledouble_files(MODELS_DIR),
+        "venv": venv_removed,
+    }
+    if writer and any(removed.values()):
+        writer.write({"event": "cleanup_appledouble", **removed})
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=["prepare", "doctor", "probe", "run", "all", "summary"])
+    parser.add_argument("--artifact-dir", type=Path, default=ARTIFACT_ROOT)
+    parser.add_argument("--input", type=Path, default=ARTIFACT_ROOT / "input" / "smoke_input.wav")
+    parser.add_argument("--duration", type=float, default=8.0)
+    parser.add_argument("--results", type=Path, default=ARTIFACT_ROOT / "smoke_results.jsonl")
+    parser.add_argument("--append", action="store_true")
+    parser.add_argument("--skip-download", action="store_true")
+    parser.add_argument("--force-download", action="store_true")
+    parser.add_argument(
+        "--phase",
+        choices=[
+            "blocking",
+            "extended",
+            "backend_modes",
+            "gpu_disabled",
+            "demucs_legacy",
+            "format_inputs",
+            "long_audio",
+            "all",
+        ],
+        default="blocking",
+    )
+    parser.add_argument("--case", help="Comma-separated case IDs to run.")
+    parser.add_argument("--continue-on-error", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    os.chdir(REPO_ROOT)
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.artifact_dir.mkdir(parents=True, exist_ok=True)
+    writer = ResultWriter(args.results, append=args.append or args.command == "summary")
+    try:
+        if args.command == "prepare":
+            return command_prepare(args, writer)
+        if args.command == "doctor":
+            return command_doctor(args, writer)
+        if args.command == "probe":
+            return command_probe(args, writer)
+        if args.command == "run":
+            return command_run(args, writer)
+        if args.command == "all":
+            return command_all(args, writer)
+        if args.command == "summary":
+            return command_summary(args, writer)
+        parser.error(f"Unknown command {args.command}")
+        return 2
+    except (SmokeError, urllib.error.URLError) as exc:
+        writer.write({"event": "fatal", "exception": repr(exc), "traceback": traceback.format_exc()})
+        print(f"smoke error: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        writer.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds a pluggable inference backend layer and enables Apple Silicon GPU acceleration through PyTorch MPS while preserving existing CUDA/CPU behavior.

## Changes

- Add backend abstraction for CPU, CUDA, MPS, and CoreML/ONNX providers
- Add Apple Silicon MPS paths for VR, MDX, MDXC, and Demucs v3/v4
- Keep CUDA as the first auto-selected backend when available
- Keep Demucs v1/v2 on the existing CPU/CUDA behavior
- Add smoke test harness for real-model inference validation
- Add macOS arm64 PyInstaller build support
- Update dependency rules so macOS does not install onnxruntime-gpu
- Ignore local build artifacts, venvs, model weights, and AppleDouble files

## Validation

- CLI smoke summary: 27/27 passed on Mac mini m4
- Functional MDX23C test used Apple GPU (MPS) with fallback=false
- macOS arm64 `.app` build completed and passed ad-hoc codesign verification