### PR TITLE
Modernize dependencies and add Linux install tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,79 @@
+# ---------------------------------------------------------------------------
+# Python
+# ---------------------------------------------------------------------------
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+dist/
+develop-eggs/
+downloads/
+eggs/
+.eggs/
+*.egg-info/
+*.egg
+.installed.cfg
+pip-log.txt
+pip-delete-this-directory.txt
+
+# ---------------------------------------------------------------------------
+# Virtual environments
+# ---------------------------------------------------------------------------
+venv/
+.venv/
+env/
+ENV/
+.python-version
+
+# ---------------------------------------------------------------------------
+# Editors / OS
+# ---------------------------------------------------------------------------
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store
+Thumbs.db
+
+# ---------------------------------------------------------------------------
+# UVR runtime-generated files
+# ---------------------------------------------------------------------------
+# User settings / cached data written on exit
+data.pkl
+
+# Temp working directories created during processing
+/tmp/
+/temp_sample_clips/
+/ensemble_temps/
+
+# Downloaded bulletin / changelog text
+/gui_data/cr_text.txt
+
+# User-saved presets generated at runtime
+/gui_data/saved_ensembles/
+/gui_data/saved_settings/
+
+# Error logs
+*.log
+
+# ---------------------------------------------------------------------------
+# Downloaded model weights (kept out of version control)
+# Config/metadata under */model_data/ and mdx_c_configs/ remain tracked.
+# ---------------------------------------------------------------------------
+/models/VR_Models/*.pth
+/models/MDX_Net_Models/*.onnx
+/models/MDX_Net_Models/*.ckpt
+/models/MDX_Net_Models/*.ckptc
+/models/Demucs_Models/*.ckpt
+/models/Demucs_Models/*.th
+/models/Demucs_Models/*.gz
+/models/Demucs_Models/*.pth
+/models/Demucs_Models/v3_v4_repo/*.th
+/models/Demucs_Models/v3_v4_repo/*.gz
+/models/Demucs_Models/v3_v4_repo/*.yaml
+/models/Demucs_Models/v3_v4_repo/*.bin
+
+# Keep model weights that ship with the repository
+!/models/VR_Models/UVR-DeNoise-Lite.pth

--- a/README.md
+++ b/README.md
@@ -164,54 +164,97 @@ This process has been tested on a MacBook Pro 2021 (using M1) and a MacBook Air 
 
 ---
 
-#### **Step 2: Install Dependencies**
+#### **Step 2: Install System Dependencies**
 Use the following commands based on your system type:
 
 **For Debian-based systems (Ubuntu, Mint, etc.):**
 ```bash
 sudo apt update && sudo apt upgrade
-sudo apt-get install -y ffmpeg python3-pip python3-tk
+sudo apt-get install -y ffmpeg python3-pip python3-venv python3-tk rubberband-cli
 ```
 
 **For Arch-based systems (EndeavourOS):**
 ```bash
 sudo pacman -Syu
-sudo pacman -S ffmpeg python-pip tk
+sudo pacman -S ffmpeg python-pip tk rubberband
 ```
+
+> `rubberband` is optional and only needed for the **Time-Stretch** and **Pitch-Shift** tools.
 
 ---
 
-#### **Step 3: Set Up a Virtual Environment (Recommended)**
-Setting up a virtual environment (venv) ensures that the program's dependencies do not interfere with system-wide Python packages.
+#### **Step 3: Install (Recommended — automated script)**
+A helper script sets up a virtual environment, auto-detects your GPU, installs
+the matching PyTorch build, and installs the remaining requirements:
 
-1. **Navigate to the extracted repository directory:**
+```bash
+cd /path/to/ultimatevocalremovergui
+chmod +x install_linux.sh
+
+./install_linux.sh              # auto-detect NVIDIA GPU vs. CPU
+./install_linux.sh --cpu        # force CPU-only PyTorch
+./install_linux.sh --cuda cu128 # pick a specific CUDA wheel index
+```
+
+Then run the application:
+```bash
+source venv/bin/activate
+python UVR.py
+```
+
+The script automatically uses [`uv`](https://github.com/astral-sh/uv) if it is
+available (much faster), otherwise it falls back to `pip`.
+
+---
+
+#### **Manual Installation (alternative)**
+
+1. **Create and activate a virtual environment:**
    ```bash
    cd /path/to/ultimatevocalremovergui
-   ```
-
-2. **Create a virtual environment:**
-   ```bash
    python3 -m venv venv
+   source venv/bin/activate
    ```
 
-3. **Activate the virtual environment:**
-   - For **Debian-based and Arch-based systems:**
-     ```bash
-     source venv/bin/activate
-     ```
+2. **Install PyTorch.** Pick the build that matches your hardware/driver — see
+   the [CUDA / PyTorch version guide](#cuda--pytorch-version-guide) below:
+   ```bash
+   # NVIDIA GPU (CUDA 12.x drivers — most common today)
+   pip install torch torchvision --index-url https://download.pytorch.org/whl/cu126
 
-4. **Install dependencies in the virtual environment:**
+   # CPU only
+   pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+   ```
+
+3. **Install the remaining dependencies:**
    ```bash
    pip install -r requirements.txt
    ```
 
+4. **Run the application:**
+   ```bash
+   python UVR.py
+   ```
+
 ---
 
-#### **Step 4: Run the Application**
-While the virtual environment is activated, start the application:
-```bash
-python UVR.py
-```
+#### **CUDA / PyTorch version guide**
+The default PyPI `torch` wheels may target a newer CUDA toolkit than your
+installed driver supports, which results in `torch.cuda.is_available()` returning
+`False`. Install the wheel that matches your driver:
+
+| NVIDIA driver / `nvidia-smi` CUDA Version | Recommended wheel index | Command suffix |
+|---|---|---|
+| CUDA **12.1 – 12.6** | `cu126` *(recommended default)* | `--index-url https://download.pytorch.org/whl/cu126` |
+| CUDA **12.8+** | `cu128` | `--index-url https://download.pytorch.org/whl/cu128` |
+| No NVIDIA GPU | `cpu` | `--index-url https://download.pytorch.org/whl/cpu` |
+
+Check your driver's supported CUDA version with `nvidia-smi` (top-right "CUDA
+Version"). When in doubt, `cu126` works with virtually all current 12.x drivers.
+
+> **Note on `onnxruntime-gpu`:** `requirements.txt` pins `onnxruntime-gpu<1.22`
+> because 1.22+ requires CUDA 13 runtime libraries. The pinned 1.21.x builds work
+> with CUDA 12.x. If you are on a CUDA 13 setup you can remove that constraint.
 
 ---
 

--- a/UVR.py
+++ b/UVR.py
@@ -49,7 +49,7 @@ from separate import (
     save_format, clear_gpu_cache,  # Utility functions
     cuda_available, mps_available, #directml_available,
 )
-from playsound import playsound
+from playsound3 import playsound
 from typing import List
 import onnx
 import re

--- a/gui_data/app_size_values.py
+++ b/gui_data/app_size_values.py
@@ -4,6 +4,9 @@ from screeninfo import get_monitors
 from PIL import Image
 from PIL import ImageTk
 
+# Pillow 10+ removed Image.ANTIALIAS; LANCZOS is the equivalent.
+_RESAMPLE = getattr(Image, "Resampling", Image).LANCZOS
+
 OPERATING_SYSTEM = platform.system()
 
 def get_screen_height():
@@ -132,9 +135,9 @@ class ImagePath():
         if size is not None:
             size = (int(size[0]), int(size[1]))
             if keep_aspect:
-                img = img.resize((size[0], int(size[0] * ratio)), Image.ANTIALIAS)
+                img = img.resize((size[0], int(size[0] * ratio)), _RESAMPLE)
             else:
-                img = img.resize(size, Image.ANTIALIAS)
+                img = img.resize(size, _RESAMPLE)
                 
         return ImageTk.PhotoImage(img)
 

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Ultimate Vocal Remover GUI - Linux installation helper
+#
+# Sets up a Python virtual environment and installs all dependencies,
+# choosing the correct PyTorch build for your system (CUDA GPU or CPU).
+#
+# Usage:
+#   ./install_linux.sh                 # auto-detect GPU/CPU
+#   ./install_linux.sh --cpu           # force CPU-only PyTorch
+#   ./install_linux.sh --cuda cu126    # force a specific CUDA wheel index
+#   ./install_linux.sh --venv .venv    # custom virtualenv directory
+#
+# After installation:
+#   source venv/bin/activate
+#   python UVR.py
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration / argument parsing
+# ---------------------------------------------------------------------------
+VENV_DIR="venv"
+FORCE_MODE=""          # "cpu" | "cuda" | "" (auto)
+CUDA_INDEX="cu126"     # default CUDA wheel index; matches CUDA 12.x drivers
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --cpu)
+            FORCE_MODE="cpu"; shift ;;
+        --cuda)
+            FORCE_MODE="cuda"; CUDA_INDEX="${2:-cu126}"; shift 2 ;;
+        --venv)
+            VENV_DIR="${2:?--venv requires a path}"; shift 2 ;;
+        -h|--help)
+            sed -n '3,17p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *)
+            echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+info()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn()  { printf '\033[1;33m[!]\033[0m %s\n' "$*"; }
+error() { printf '\033[1;31m[x]\033[0m %s\n' "$*" >&2; }
+
+# ---------------------------------------------------------------------------
+# System dependency check (informational; we don't auto-install with sudo)
+# ---------------------------------------------------------------------------
+info "Checking system dependencies (ffmpeg, python3, tk, rubberband)..."
+MISSING_SYS=()
+command -v ffmpeg      >/dev/null 2>&1 || MISSING_SYS+=("ffmpeg")
+command -v python3     >/dev/null 2>&1 || MISSING_SYS+=("python3")
+command -v rubberband  >/dev/null 2>&1 || MISSING_SYS+=("rubberband (optional: Time-Stretch / Pitch-Shift)")
+python3 -c "import tkinter" >/dev/null 2>&1 || MISSING_SYS+=("python3-tk")
+
+if [[ ${#MISSING_SYS[@]} -gt 0 ]]; then
+    warn "The following system packages appear to be missing:"
+    for pkg in "${MISSING_SYS[@]}"; do echo "      - $pkg"; done
+    echo
+    echo "  Install them first, for example:"
+    echo "    Debian/Ubuntu: sudo apt-get install -y ffmpeg python3-pip python3-tk rubberband-cli"
+    echo "    Arch/Endeavour: sudo pacman -S ffmpeg python-pip tk rubberband"
+    echo
+fi
+
+# ---------------------------------------------------------------------------
+# GPU / CUDA detection
+# ---------------------------------------------------------------------------
+MODE="$FORCE_MODE"
+if [[ -z "$MODE" ]]; then
+    if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi >/dev/null 2>&1; then
+        MODE="cuda"
+        info "NVIDIA GPU detected -> installing CUDA PyTorch (index: $CUDA_INDEX)."
+    else
+        MODE="cpu"
+        info "No NVIDIA GPU detected -> installing CPU-only PyTorch."
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Virtual environment + pip front-end (prefer uv if available)
+# ---------------------------------------------------------------------------
+if [[ ! -d "$VENV_DIR" ]]; then
+    info "Creating virtual environment in '$VENV_DIR'..."
+    python3 -m venv "$VENV_DIR"
+fi
+
+# shellcheck disable=SC1090
+source "$VENV_DIR/bin/activate"
+
+if command -v uv >/dev/null 2>&1; then
+    PIP_INSTALL=(uv pip install)
+elif python -m uv --version >/dev/null 2>&1; then
+    PIP_INSTALL=(python -m uv pip install)
+else
+    info "Upgrading pip..."
+    python -m pip install --upgrade pip >/dev/null
+    PIP_INSTALL=(python -m pip install)
+fi
+info "Using installer: ${PIP_INSTALL[*]}"
+
+# ---------------------------------------------------------------------------
+# Install PyTorch first (correct build), then the rest of requirements
+# ---------------------------------------------------------------------------
+if [[ "$MODE" == "cuda" ]]; then
+    info "Installing torch / torchvision (CUDA $CUDA_INDEX)..."
+    "${PIP_INSTALL[@]}" torch torchvision \
+        --index-url "https://download.pytorch.org/whl/${CUDA_INDEX}"
+else
+    info "Installing torch / torchvision (CPU)..."
+    "${PIP_INSTALL[@]}" torch torchvision \
+        --index-url "https://download.pytorch.org/whl/cpu"
+fi
+
+info "Installing remaining requirements..."
+"${PIP_INSTALL[@]}" -r requirements.txt
+
+# ---------------------------------------------------------------------------
+# Verify
+# ---------------------------------------------------------------------------
+info "Verifying installation..."
+python - <<'PY'
+import torch
+print(f"  torch {torch.__version__}")
+print(f"  CUDA available: {torch.cuda.is_available()}")
+if torch.cuda.is_available():
+    print(f"  GPU: {torch.cuda.get_device_name(0)} (x{torch.cuda.device_count()})")
+PY
+
+echo
+info "Done! To run the application:"
+echo "    source $VENV_DIR/bin/activate"
+echo "    python UVR.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,42 +1,55 @@
-altgraph==0.17.3
-audioread==3.0.0
-certifi==2022.12.07
-cffi==1.15.1
-cryptography==3.4.6
-einops==0.6.0
-future==0.18.3
-julius==0.2.7
-kthread==0.2.3
-librosa==0.9.2
-llvmlite
-matchering==2.0.6
-ml_collections==0.1.1
-natsort==8.2.0
-omegaconf==2.2.3
-opencv-python==4.6.0.66
-Pillow==9.3.0
-psutil==5.9.4
-pydub==0.25.1
-pyglet==1.5.23
-pyperclip==1.8.2
-pyrubberband==0.3.0
-pytorch_lightning==2.0.0
-PyYAML==6.0
-resampy==0.4.2
-scipy==1.9.3
-soundstretch==1.2
-torch
-urllib3==1.26.12
-wget==3.2
-samplerate==0.1.0
-screeninfo==0.8.1
+# Ultimate Vocal Remover GUI - Python dependencies
+#
+# Install (conda env uvr recommended):
+#   python -m uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cu126
+#   python -m uv pip install -r requirements.txt
+#
+# For CPU-only systems, install torch from PyPI instead:
+#   python -m uv pip install torch torchvision
+#   python -m uv pip install -r requirements.txt
+#
+# Versions are left unpinned unless a newer major is known to break the app.
+
+# --- Scientific / audio core ---
+numpy
+scipy
+librosa
+soundfile
+audioread
+pydub
+resampy
+six
+
+# --- Deep learning (install torch/torchvision separately; see header) ---
+einops
+julius
+omegaconf
 diffq
-playsound
+pytorch_lightning
+ml_collections
+
+# --- ONNX runtime / conversion ---
 onnx
-onnxruntime
-onnxruntime-gpu
+# ONNX GPU runtime: 1.21.x targets CUDA 12.x; 1.22+ requires CUDA 13.
+onnxruntime-gpu>=1.19,<1.22
 onnx2pytorch
-SoundFile==0.11.0; sys_platform != 'darwin'
-PySoundFile==0.9.0.post1; sys_platform == 'darwin'
-Dora==0.0.3
-numpy==1.23.5
+
+# --- Audio mastering ---
+matchering
+
+# --- GUI / application ---
+pyglet
+pyperclip
+natsort
+psutil
+screeninfo
+Pillow
+PyYAML
+wget
+kthread
+tqdm
+cryptography
+playsound3
+
+# --- Platform-specific helpers ---
+pyrubberband; sys_platform == 'win32'


### PR DESCRIPTION
Update requirements.txt to drop outdated pins and dead dependencies (opencv, samplerate, soundstretch, Dora, etc.), unpin to modern versions, and add missing direct deps (six, tqdm). Pin onnxruntime-gpu<1.22 to keep CUDA 12.x compatibility.

Fix compatibility with current libraries:
- switch to playsound3 import
- replace removed Pillow Image.ANTIALIAS with LANCZOS

Add install_linux.sh helper (venv setup, GPU/CPU autodetect, correct PyTorch wheel index, uv/pip fallback) and refresh the README Linux section with a CUDA/PyTorch version guide. Add a .gitignore covering Python artifacts, virtualenvs, editor files, UVR runtime files, and downloaded model weights.